### PR TITLE
ci(.github/workflows/worker.yml): only use first line of commit message for worker version

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           sha=${{ github.event.pull_request.head.sha || github.sha }}
           short_sha=$(git rev-parse --short "${sha}")
-          message=$(git log --format=%B --max-count=1 "${sha}")
+          message=$(git log --format=%B --max-count=1 "${sha}" | head --lines=1)
           echo "short_sha=${short_sha}" >> "${GITHUB_OUTPUT}"
           echo "message=${message}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
GitHub Actions outputs doesn't support multiline strings
