### PR TITLE
ci(.github/workflows/wsl-dcoker.yml): disable push and pull_request triggers

### DIFF
--- a/.github/workflows/wsl-docker.yml
+++ b/.github/workflows/wsl-docker.yml
@@ -4,16 +4,16 @@ on:
   schedule:
     # update once a week
     - cron: "0 0 * * SUN"
-  push:
-    branches:
-      - main
-    paths:
-      - .github/workflows/wsl-docker.yml
-  pull_request:
-    branches:
-      - main
-    paths:
-      - .github/workflows/wsl-docker.yml
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - .github/workflows/wsl-docker.yml
+  # pull_request:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - .github/workflows/wsl-docker.yml
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Ubuntu Cloud Images stopped offering rootfs tar files from the `20250203` release. Not sure of the reason, so disable it temporarily.
https://cloud-images.ubuntu.com/wsl/noble/20250130/
https://cloud-images.ubuntu.com/wsl/noble/20250203/