### PR TITLE
Revert "fix(wsl/home/.config/mise/config.toml): manage env vars using mise (#1071)"

### DIFF
--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -120,7 +120,7 @@ export GPG_TTY
 
 # set GITHUB_TOKEN to avoid rate limit while using mise
 # use __CI instead of CI to be able to test CI locally
-if [[ -z "${__CI}" ]]; then
+if [[ -z ${__CI} ]]; then
 	GITHUB_TOKEN=$(gh auth token)
 	export GITHUB_TOKEN
 fi

--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -111,6 +111,20 @@ eval "${gh_completion}"
 fzf_integration="$(fzf --bash)"
 eval "${fzf_integration}"
 
+# gpg requires tty
+# GitHub Actions doesn't have tty
+# ref: https://github.com/actions/runner/issues/241
+# don't cache tty because it depends on shell session
+GPG_TTY=$(tty)
+export GPG_TTY
+
+# set GITHUB_TOKEN to avoid rate limit while using mise
+# use __CI instead of CI to be able to test CI locally
+if [[ -z "${__CI}" ]]; then
+	GITHUB_TOKEN=$(gh auth token)
+	export GITHUB_TOKEN
+fi
+
 # aliases
 alias beep="printf '\a'"
 alias l="eza --all --long --git"

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -6,24 +6,6 @@ min_version = "2025.5.8"
 [env]
 # disable bat paging
 BAT_PAGING = "never"
-# gpg requires tty
-# GitHub Actions doesn't have tty
-# ref: https://github.com/actions/runner/issues/241
-# don't cache tty because it depends on shell session
-GPG_TTY = "{{ exec(command='tty || true') }}"
-
-# set GITHUB_TOKEN to avoid rate limit while using mise
-[env.GITHUB_TOKEN]
-# use __CI instead of CI to be able to test CI locally
-value = """
-{% if env.__CI is undefined %}\
-  {{ exec(command='gh auth token || true', cache_key='github_token', cache_duration='1 day') }}\
-{% else %}\
-  {{ env.GITHUB_TOKEN | default(value='') }}\
-{% endif %}\
-"""
-tools = true
-redact = true
 
 [tools]
 # language tools

--- a/wsl/setup-git.ts
+++ b/wsl/setup-git.ts
@@ -1342,10 +1342,6 @@ const main = async (): Promise<void> => {
 		await removeScopes();
 	}
 
-	// invalidate mise exec template cache after github authentication
-	const miseCacheDir = (await $`mise cache`.text()).trim();
-	await $`rm --force --recursive ${resolve(miseCacheDir, "./exec")}`.quiet();
-
 	// reset gh config because it is formatted differently by gh cli
 	const ghConfigPath = resolve(
 		import.meta.dirname,


### PR DESCRIPTION
This reverts commit c2062568eee51917de56346deca792aaf8767082.

Cache causes some problems, so simply manage it in `.bashrc`.
e.g. `GITHUB_TOKEN` not updated
