### PR TITLE
chore(mise): unpin tool versions and add copilot

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,29 +7,37 @@ min_version = "2026.4.18"
 PS_SCRIPT_ANALYZER_VERSION = "1.25.0"
 
 [tools]
-bun = "1.3.13"
-node = "24.15.0"
-oxlint = "1.57.0"
-oxfmt = "0.46.0"
-actionlint = "1.7.12"
-ghalint = "1.5.5"
-pinact = "3.9.0"
-zizmor = "1.11.0"
-taplo = "0.10.0"
-markdownlint-cli2 = "0.22.1"
-shfmt = "3.13.1"
-shellcheck = "0.11.0"
-yamlfmt = "0.21.0"
+# core runtimes
+bun = "latest"
+node = "latest"
+
+# linter/formatter tools
+oxlint = "latest"
+oxfmt = "latest"
+actionlint = "latest"
+ghalint = "latest"
+pinact = "latest"
+zizmor = "latest"
+taplo = "latest"
+markdownlint-cli2 = "latest"
+shfmt = "latest"
+shellcheck = "latest"
+yamlfmt = "latest"
+yamllint = "latest"
+lychee = "latest"
+typos = "latest"
+hadolint = "latest"
+
+# npm packages
+"npm:ignore-sync" = "latest"
+"npm:jschema-validator" = "latest"
+
+# other tools
 # required for pipx backend
-uv = "0.11.7"
-yamllint = "1.38.0"
-lychee = "0.23.0"
-typos = "1.45.1"
-"npm:ignore-sync" = "8.0.0"
-"npm:jschema-validator" = "1.0.27"
-jc = "1.25.6"
-hadolint = "2.14.0"
-powershell = "7.6.1"
+uv = "latest"
+jc = "latest"
+powershell = "latest"
+copilot = "latest"
 
 [settings]
 experimental = true


### PR DESCRIPTION
## Summary
- unpin versions in root `mise.toml` (switch to `latest`)
- add `copilot` to the root toolset
- reorganize `[tools]` into commented segments

## Test plan
- [x] Inspect `mise.toml` diff for TOML validity

Made with [Cursor](https://cursor.com)