### PR TITLE
chore(mise): unpin WSL tools

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -44,19 +44,20 @@ sd = "latest"
 kubecolor = "latest"
 kubectl = "latest"
 kubectx = "latest"
-kubeseal = "0.36.6"
+kubeseal = "latest"
 mitmproxy = "latest"
-doggo = "1.1.5"
+doggo = "latest"
 pitchfork = "latest"
 miller = "latest"
 glow = "latest"
-"github:garden-rs/garden" = "2.6.0"
+"github:garden-rs/garden" = "latest"
 
 # ai agents
 codex = "latest"
 claude = "latest"
 gemini-cli = "latest"
 opencode = "latest"
+copilot = "latest"
 
 # linter/formatter tools
 biome = "latest"
@@ -78,12 +79,11 @@ hadolint = "latest"
 
 # uni tools
 numbat = "latest"
-typst = "0.14.2"
+typst = "latest"
 
 # mise development
 aqua = "latest"
 vfox = "latest"
-copilot = "1.0.43"
 
 [settings]
 pin = true

--- a/wsl/home/.config/mise/mise.lock
+++ b/wsl/home/.config/mise/mise.lock
@@ -438,12 +438,12 @@ checksum = "sha256:9a4316d633243aa54308ff3bf6970923b18c105dea34fbc3009d51889e1dd
 url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-x86_64-unknown-linux-musl.tar.gz"
 
 [[tools.uv]]
-version = "0.11.8"
+version = "0.11.11"
 backend = "aqua:astral-sh/uv"
 
 [tools.uv."platforms.linux-x64"]
-checksum = "sha256:de82507d12e31cfc86c1c776238f7c248e48e40d996dedc812d64fdd31c6ed12"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.8/uv-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:80521f18ba83109acd17e0730bd8ff898c3426aa62252c627d63418b353e788a"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.11/uv-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [[tools.vfox]]


### PR DESCRIPTION
## Summary
- unpin remaining pinned WSL tools to `latest`
- add `copilot` and supporting tooling (`pipx`, `aube`, `sccache`) in WSL global mise config
- set `RUSTC_WRAPPER=sccache`

## Test plan
- [x] `mise run check:taplo`

Made with [Cursor](https://cursor.com)