### PR TITLE
fix(ci): allow unlocked mise install in autofix

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -32,7 +32,6 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.2
-          install_args: --locked
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
- remove `install_args: --locked` from the autofix workflow's `mise-action` step
- keep lockfile regeneration step in autofix (`mise lock --platform linux-x64`)

## Test plan
- [x] `mise run check:actionlint`

Made with [Cursor](https://cursor.com)