### PR TITLE
chore(mise): add sccache and rustc wrapper

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -2,6 +2,7 @@
 #:schema https://mise.jdx.dev/schema/mise.json
 
 [env]
+RUSTC_WRAPPER = "sccache"
 # disable bat paging
 BAT_PAGING = "never"
 
@@ -85,6 +86,7 @@ typst = "latest"
 # mise development
 aqua = "latest"
 vfox = "latest"
+sccache = "latest"
 
 [settings]
 pin = true

--- a/wsl/home/.config/mise/mise.lock
+++ b/wsl/home/.config/mise/mise.lock
@@ -389,6 +389,14 @@ url = "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15
 version = "1.95.0"
 backend = "core:rust"
 
+[[tools.sccache]]
+version = "0.15.0"
+backend = "aqua:mozilla/sccache"
+
+[tools.sccache."platforms.linux-x64"]
+checksum = "sha256:782d2b5dd7ae0a55ebe368ab258114d0928d019ac2d949ab85d5d02f3926709e"
+url = "https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-x86_64-unknown-linux-musl.tar.gz"
+
 [[tools.sd]]
 version = "1.1.0"
 backend = "aqua:chmln/sd"


### PR DESCRIPTION
## Summary
- add `sccache` to WSL global mise tools
- set `RUSTC_WRAPPER=sccache` in global mise env
- refresh global lockfile for linux-x64

## Test plan
- [x] `mise lock --global --platform linux-x64`
- [x] `mise run check:taplo`

Made with [Cursor](https://cursor.com)