### PR TITLE
chore(mise): add aube and switch npm package manager

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -24,6 +24,16 @@ checksum = "sha256:8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
 provenance = "github-attestations"
 
+[[tools.aube]]
+version = "1.8.0"
+backend = "github:endevco/aube"
+
+[tools.aube."platforms.linux-x64"]
+checksum = "sha256:298ff8f1a1820a68a369d03c3dfa46aca8ccbceb1a4facd97329b10a03322abb"
+url = "https://github.com/endevco/aube/releases/download/v1.8.0/aube-v1.8.0-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/411329171"
+provenance = "github-attestations"
+
 [[tools.bun]]
 version = "1.3.13"
 backend = "core:bun"

--- a/mise.toml
+++ b/mise.toml
@@ -35,7 +35,7 @@ powershell = "7.6.1"
 experimental = true
 
 [settings.npm]
-package_manager = "bun"
+package_manager = "aube"
 
 [task_config]
 includes = ["tasks.toml", "tasks", "worker/tasks.toml", "worker/tasks"]

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ PS_SCRIPT_ANALYZER_VERSION = "1.25.0"
 
 [tools]
 bun = "1.3.13"
+aube = "1.8.0"
 node = "24.15.0"
 oxlint = "1.62.0"
 oxfmt = "0.47.0"

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -85,13 +85,14 @@ typst = "latest"
 # mise development
 aqua = "latest"
 vfox = "latest"
+aube = "latest"
 
 [settings]
 pin = true
 experimental = true
 
 [settings.npm]
-package_manager = "bun"
+package_manager = "aube"
 
 [settings.python]
 # disable python-build

--- a/wsl/home/.config/mise/mise.lock
+++ b/wsl/home/.config/mise/mise.lock
@@ -36,6 +36,16 @@ backend = "aqua:yarn"
 [tools."aqua:yarn"."platforms.linux-x64"]
 url = "https://repo.yarnpkg.com/4.14.1/packages/yarnpkg-cli/bin/yarn.js"
 
+[[tools.aube]]
+version = "1.8.0"
+backend = "github:endevco/aube"
+
+[tools.aube."platforms.linux-x64"]
+checksum = "sha256:298ff8f1a1820a68a369d03c3dfa46aca8ccbceb1a4facd97329b10a03322abb"
+url = "https://github.com/endevco/aube/releases/download/v1.8.0/aube-v1.8.0-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/411329171"
+provenance = "github-attestations"
+
 [[tools.bat]]
 version = "0.26.1"
 backend = "aqua:sharkdp/bat"


### PR DESCRIPTION
## Summary
- add `aube` to WSL global mise tools
- set `[settings.npm].package_manager = "aube"`
- refresh global lockfile for linux-x64

## Test plan
- [x] `mise lock --global --platform linux-x64`
- [x] `mise run check:taplo`

Made with [Cursor](https://cursor.com)