### PR TITLE
chore(mise): add pipx for global development tools

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -85,6 +85,7 @@ typst = "latest"
 # mise development
 aqua = "latest"
 vfox = "latest"
+pipx = "latest"
 
 [settings]
 pin = true

--- a/wsl/home/.config/mise/mise.lock
+++ b/wsl/home/.config/mise/mise.lock
@@ -341,6 +341,14 @@ checksum = "sha256:6adcc8a2217e4114e0841f8bca0cddf9958a9c52e3e89760c35b791cdba1a
 url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.2/pinact_linux_amd64.tar.gz"
 provenance = "github-attestations"
 
+[[tools.pipx]]
+version = "1.11.1"
+backend = "aqua:pypa/pipx"
+
+[tools.pipx."platforms.linux-x64"]
+checksum = "sha256:60c947d2449af642c17079a2119ef87e426ad83967b8bb223bb27c802fc29ccd"
+url = "https://github.com/pypa/pipx/releases/download/1.11.1/pipx.pyz"
+
 [[tools."pipx:markitdown"]]
 version = "0.1.5"
 backend = "pipx:markitdown"


### PR DESCRIPTION
## Summary
- add `pipx` under the WSL global mise development tools section
- refresh global lockfile for linux-x64

## Test plan
- [x] `mise lock --global --platform linux-x64`
- [x] `mise run check:taplo`

Made with [Cursor](https://cursor.com)