### PR TITLE
chore(mise): add hk linter tool

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -61,6 +61,7 @@ opencode = "latest"
 copilot = "latest"
 
 # linter/formatter tools
+hk = "latest"
 biome = "latest"
 oxlint = "latest"
 oxfmt = "latest"

--- a/wsl/home/.config/mise/mise.lock
+++ b/wsl/home/.config/mise/mise.lock
@@ -210,6 +210,14 @@ backend = "aqua:hadolint/hadolint"
 checksum = "sha256:6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47"
 url = "https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-linux-x86_64"
 
+[[tools.hk]]
+version = "1.45.0"
+backend = "aqua:jdx/hk"
+
+[tools.hk."platforms.linux-x64"]
+checksum = "sha256:47a3338403f689cc295d36213cfede4e1098c335d18064416ea9ac2b9739c148"
+url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-x86_64-unknown-linux-gnu.tar.gz"
+
 [[tools.java]]
 version = "26.0.1"
 backend = "core:java"


### PR DESCRIPTION
## Summary
- add `hk` to the WSL linter/formatter tool section
- refresh global lockfile for linux-x64

## Test plan
- [x] `mise lock --global --platform linux-x64`
- [x] `mise run check:taplo`

Made with [Cursor](https://cursor.com)