### PR TITLE
chore(bash): completions for mise aliases, kubectl/yq, and kubectx

### DIFF
--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -74,6 +74,27 @@ if ! shopt -oq posix && [[ -f /usr/share/bash-completion/bash_completion ]]; the
 	source /usr/share/bash-completion/bash_completion
 fi
 
+# kubectl completion (`__start_kubectl` is required for kubecolor below)
+# ref: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#enable-shell-autocompletion
+# ref: https://kubernetes.io/docs/reference/kubectl/generated/kubectl_completion/
+if command -v kubectl &>/dev/null; then
+	kubectl_completion="$(kubectl completion bash)"
+	eval "${kubectl_completion}"
+fi
+
+# kubecolor and the mise `k` shell_alias share kubectl’s completion
+# ref: https://kubecolor.github.io/setup/shells/bash/
+if command -v kubectl &>/dev/null && command -v kubecolor &>/dev/null; then
+	complete -o default -F __start_kubectl kubecolor
+	complete -o default -F __start_kubectl k
+fi
+
+# ref: https://mikefarah.gitbook.io/yq/v/v4.x/commands/shell-completion
+if command -v yq &>/dev/null; then
+	yq_completion="$(yq shell-completion bash)"
+	eval "${yq_completion}"
+fi
+
 # Activate pitchfork
 if command -v mise &>/dev/null; then
 	mise_activate="$(pitchfork activate bash)"
@@ -108,7 +129,7 @@ if command -v ghr &>/dev/null; then
 	eval "${ghr_completion}"
 fi
 
-# Alias completions
+# mise shell_alias completions (`m` → mise, `mx` → mise x)
 if declare -f _mise >/dev/null; then
 	complete -F _mise m
 	_mx_complete() {
@@ -120,18 +141,6 @@ if declare -f _mise >/dev/null; then
 		_mise
 	}
 	complete -F _mx_complete mx
-fi
-if declare -f __start_kubectl >/dev/null; then
-	complete -o default -F __start_kubectl k
-fi
-
-# Alias completions
-if declare -f _mise >/dev/null; then
-	complete -F _mise m
-	complete -F _mise mx
-fi
-if declare -f __start_kubectl >/dev/null; then
-	complete -o default -F __start_kubectl k
 fi
 
 # gpg requires tty

--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -111,6 +111,23 @@ fi
 # Alias completions
 if declare -f _mise >/dev/null; then
 	complete -F _mise m
+	_mx_complete() {
+		local original_words=("${COMP_WORDS[@]}")
+		local original_cword=${COMP_CWORD}
+
+		COMP_WORDS=("mise" "x" "${original_words[@]:1}")
+		COMP_CWORD=$((original_cword + 1))
+		_mise
+	}
+	complete -F _mx_complete mx
+fi
+if declare -f __start_kubectl >/dev/null; then
+	complete -o default -F __start_kubectl k
+fi
+
+# Alias completions
+if declare -f _mise >/dev/null; then
+	complete -F _mise m
 	complete -F _mise mx
 fi
 if declare -f __start_kubectl >/dev/null; then

--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -108,6 +108,15 @@ if command -v ghr &>/dev/null; then
 	eval "${ghr_completion}"
 fi
 
+# Alias completions
+if declare -f _mise >/dev/null; then
+	complete -F _mise m
+	complete -F _mise mx
+fi
+if declare -f __start_kubectl >/dev/null; then
+	complete -o default -F __start_kubectl k
+fi
+
 # gpg requires tty
 # GitHub Actions doesn't have tty
 # ref: https://github.com/actions/runner/issues/241

--- a/wsl/home/.local/share/bash-completion/completions/kubectx
+++ b/wsl/home/.local/share/bash-completion/completions/kubectx
@@ -1,0 +1,9 @@
+# From https://github.com/ahmetb/kubectx/blob/master/completion/kubectx.bash (see repository README “Shell completion scripts” → bash)
+_kube_contexts()
+{
+ local curr_arg;
+ curr_arg=${COMP_WORDS[COMP_CWORD]}
+ COMPREPLY=( $(compgen -W "- $(kubectl config get-contexts --output='name')" -- $curr_arg ) );
+}
+
+complete -F _kube_contexts kubectx kctx

--- a/wsl/home/.local/share/bash-completion/completions/kubens
+++ b/wsl/home/.local/share/bash-completion/completions/kubens
@@ -1,0 +1,9 @@
+# From https://github.com/ahmetb/kubectx/blob/master/completion/kubens.bash (see repository README “Shell completion scripts” → bash)
+_kube_namespaces()
+{
+ local curr_arg;
+ curr_arg=${COMP_WORDS[COMP_CWORD]}
+ COMPREPLY=( $(compgen -W "- $(kubectl get namespaces -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}')" -- $curr_arg ) );
+}
+
+complete -F _kube_namespaces kubens kns


### PR DESCRIPTION
## Summary

- Eval **`kubectl` bash completion** so `__start_kubectl` exists before any kubectl-based completions ([install guide](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#enable-shell-autocompletion); [`kubectl completion` reference](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_completion/)).
- Register **kubecolor** and the mise **`k`** shell alias with kubectl’s completion per [kubecolor Bash setup](https://kubecolor.github.io/setup/shells/bash/).
- Load **`yq`** completion with **`yq shell-completion bash`** ([yq shell completion](https://mikefarah.gitbook.io/yq/v/v4.x/commands/shell-completion)).
- **Vendor** `kubectx` and `kubens` bash completion scripts from [ahmetb/kubectx `completion/`](https://github.com/ahmetb/kubectx/tree/master/completion) under `~/.local/share/bash-completion/completions/` so bash-completion loads them on demand ([README “Shell completion scripts” → bash](https://github.com/ahmetb/kubectx/blob/master/README.md)).
- **Alias completions** for mise: **`m`** via `_mise`, **`mx`** via a small shim that completes like `mise x`; removed the duplicated block left from an earlier fixup.

## Test plan

- [x] `mise run check:shellcheck`

Made with [Cursor](https://cursor.com)
