### PR TITLE
chore(gitignore): add .codex to synced ignore rules

### DIFF
--- a/wsl/home/.config/git/.gitignore
+++ b/wsl/home/.config/git/.gitignore
@@ -745,3 +745,4 @@ dkms.conf
 !ENV/
 !lib/
 mise-local-tasks/
+.codex

--- a/wsl/home/.config/git/.gitignore-sync
+++ b/wsl/home/.config/git/.gitignore-sync
@@ -22,3 +22,4 @@ C.gitignore
 !ENV/
 !lib/
 mise-local-tasks/
+.codex


### PR DESCRIPTION
## Summary
- add `.codex` to `wsl/home/.config/git/.gitignore-sync`
- regenerate `wsl/home/.config/git/.gitignore` via ignore-sync

## Test plan
- [x] `mise run check:ignore-sync`

Made with [Cursor](https://cursor.com)