### PR TITLE
chore(glow): add symlinked glow config

### DIFF
--- a/wsl/home/.config/glow/glow.yml
+++ b/wsl/home/.config/glow/glow.yml
@@ -8,13 +8,3 @@ pager: false
 width: 80
 # show all files, including hidden and ignored.
 all: false
-# style name or JSON path (default "auto")
-style: "auto"
-# mouse support (TUI-mode only)
-mouse: false
-# use pager to display markdown
-pager: false
-# word-wrap at width
-width: 80
-# show all files, including hidden and ignored.
-all: false

--- a/wsl/home/.config/glow/glow.yml
+++ b/wsl/home/.config/glow/glow.yml
@@ -1,0 +1,20 @@
+# style name or JSON path (default "auto")
+style: "auto"
+# mouse support (TUI-mode only)
+mouse: false
+# use pager to display markdown
+pager: false
+# word-wrap at width
+width: 80
+# show all files, including hidden and ignored.
+all: false
+# style name or JSON path (default "auto")
+style: "auto"
+# mouse support (TUI-mode only)
+mouse: false
+# use pager to display markdown
+pager: false
+# word-wrap at width
+width: 80
+# show all files, including hidden and ignored.
+all: false


### PR DESCRIPTION
## Summary
- add `wsl/home/.config/glow/glow.yml`
- rely on existing install symlink flow to place it in `~/.config/glow`

## Test plan
- [x] Verify file is under the symlinked WSL home config tree

Made with [Cursor](https://cursor.com)