### PR TITLE
chore(bash): enable hk completion

### DIFF
--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -129,6 +129,12 @@ if command -v ghr &>/dev/null; then
 	eval "${ghr_completion}"
 fi
 
+# ref: https://hk.jdx.dev/cli/completion.html — requires `usage` on PATH (mise installs it globally)
+if command -v hk &>/dev/null; then
+	hk_completion="$(hk completion bash)"
+	eval "${hk_completion}"
+fi
+
 # mise shell_alias completions (`m` → mise, `mx` → mise x)
 if declare -f _mise >/dev/null; then
 	complete -F _mise m


### PR DESCRIPTION
## Summary

Adds interactive bash completion for [`hk`](https://github.com/jdx/hk), matching the existing pattern (`gh`, `mise`, `pitchfork`, `ghr`).

## Notes

- Generated script is from `hk completion bash` (see [hk completion docs](https://hk.jdx.dev/cli/completion.html)).
- Completions call the `usage` CLI at tab time; this repo already installs `usage` globally in `wsl/home/.config/mise/config.toml` for mise completion.


Made with [Cursor](https://cursor.com)