### PR TITLE
feat(mise): add @ccusage/codex and Codex shell aliases

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -34,6 +34,24 @@ url = "https://github.com/endevco/aube/releases/download/v1.8.0/aube-v1.8.0-x86_
 url_api = "https://api.github.com/repos/endevco/aube/releases/assets/411329171"
 provenance = "github-attestations"
 
+[tools.aube."platforms.linux-x64-baseline"]
+checksum = "sha256:298ff8f1a1820a68a369d03c3dfa46aca8ccbceb1a4facd97329b10a03322abb"
+url = "https://github.com/endevco/aube/releases/download/v1.8.0/aube-v1.8.0-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/411329171"
+provenance = "github-attestations"
+
+[tools.aube."platforms.linux-x64-musl"]
+checksum = "sha256:332379d6b167c83b7ab7d5a393e55f9dcea5185d3819ee5211739a6d81dba328"
+url = "https://github.com/endevco/aube/releases/download/v1.8.0/aube-v1.8.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/411310212"
+provenance = "github-attestations"
+
+[tools.aube."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:332379d6b167c83b7ab7d5a393e55f9dcea5185d3819ee5211739a6d81dba328"
+url = "https://github.com/endevco/aube/releases/download/v1.8.0/aube-v1.8.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/411310212"
+provenance = "github-attestations"
+
 [[tools.bun]]
 version = "1.3.13"
 backend = "core:bun"

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -108,6 +108,4 @@ mx = "mise x"
 l = "eza --all --long --git"
 k = "kubecolor"
 aptup = "sudo apt update && sudo apt upgrade -y"
-# OpenAI Codex via mise (npm backend also exposes ccusage-codex for analytics)
-codex = "mise x -- codex"
 cux = "ccusage-codex"

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -57,6 +57,7 @@ glow = "latest"
 
 # ai agents
 codex = "latest"
+"npm:@ccusage/codex" = "latest"
 claude = "latest"
 gemini-cli = "latest"
 copilot = "latest"
@@ -107,3 +108,6 @@ mx = "mise x"
 l = "eza --all --long --git"
 k = "kubecolor"
 aptup = "sudo apt update && sudo apt upgrade -y"
+# OpenAI Codex via mise (npm backend also exposes ccusage-codex for analytics)
+codex = "mise x -- codex"
+cux = "ccusage-codex"

--- a/wsl/home/.config/mise/mise.lock
+++ b/wsl/home/.config/mise/mise.lock
@@ -326,6 +326,10 @@ url = "https://nodejs.org/dist/v25.9.0/node-v25.9.0-linux-x64.tar.gz"
 version = "11.13.0"
 backend = "npm:npm"
 
+[[tools."npm:@ccusage/codex"]]
+version = "18.0.11"
+backend = "npm:@ccusage/codex"
+
 [[tools.numbat]]
 version = "1.23.0"
 backend = "aqua:sharkdp/numbat"


### PR DESCRIPTION
Installs `npm:@ccusage/codex` (bin: `ccusage-codex`) alongside the existing registry `codex` (OpenAI CLI). Adds `[shell_alias]` entries: `codex` runs via `mise x` and `cux` invokes `ccusage-codex`. Refreshes `wsl/home/.config/mise/mise.lock` for linux-x64.

Split from the combined Codex/tmux PLAN item; does not include the tmux task.

Made with [Cursor](https://cursor.com)