### PR TITLE
feat(mise): add codex-tmux global task

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -34,6 +34,24 @@ url = "https://github.com/endevco/aube/releases/download/v1.8.0/aube-v1.8.0-x86_
 url_api = "https://api.github.com/repos/endevco/aube/releases/assets/411329171"
 provenance = "github-attestations"
 
+[tools.aube."platforms.linux-x64-baseline"]
+checksum = "sha256:298ff8f1a1820a68a369d03c3dfa46aca8ccbceb1a4facd97329b10a03322abb"
+url = "https://github.com/endevco/aube/releases/download/v1.8.0/aube-v1.8.0-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/411329171"
+provenance = "github-attestations"
+
+[tools.aube."platforms.linux-x64-musl"]
+checksum = "sha256:332379d6b167c83b7ab7d5a393e55f9dcea5185d3819ee5211739a6d81dba328"
+url = "https://github.com/endevco/aube/releases/download/v1.8.0/aube-v1.8.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/411310212"
+provenance = "github-attestations"
+
+[tools.aube."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:332379d6b167c83b7ab7d5a393e55f9dcea5185d3819ee5211739a6d81dba328"
+url = "https://github.com/endevco/aube/releases/download/v1.8.0/aube-v1.8.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/411310212"
+provenance = "github-attestations"
+
 [[tools.bun]]
 version = "1.3.13"
 backend = "core:bun"

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -100,10 +100,14 @@ package_manager = "aube"
 # disable python-build
 compile = false
 
+[task_config]
+includes = [".config/mise/tasks"]
+
 [shell_alias]
 clip = "clip.exe"
 m = "mise"
 mx = "mise x"
+c = "mise run codex-tmux"
 l = "eza --all --long --git"
 k = "kubecolor"
 aptup = "sudo apt update && sudo apt upgrade -y"

--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -37,17 +37,17 @@ _hash="$(hash_pwd)"
 BASE_NAME="codex-${_dir_safe}-${_hash}"
 SESSION_NAME="${BASE_NAME}"
 
-if [[ "${NEW_SESSION}" == "true" ]]; then
+if [[ ${NEW_SESSION} == "true" ]]; then
 	SESSION_NAME="${BASE_NAME}-$(date +%Y%m%d%H%M%S)-$$"
 elif tmux has-session -t "=${SESSION_NAME}" 2>/dev/null; then
-	if [[ -n "${TMUX:-}" ]]; then
+	if [[ -n ${TMUX:-} ]]; then
 		exec tmux switch-client -t "=${SESSION_NAME}"
 	else
 		exec tmux attach-session -t "=${SESSION_NAME}"
 	fi
 fi
 
-if [[ -n "${TMUX:-}" ]]; then
+if [[ -n ${TMUX:-} ]]; then
 	tmux new-session -d -s "${SESSION_NAME}" -c "${PWD_REAL}" codex
 	exec tmux switch-client -t "=${SESSION_NAME}"
 else

--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -4,6 +4,16 @@
 
 set -euo pipefail
 
+if ! command -v codex >/dev/null 2>&1; then
+	echo "error: codex command not found" >&2
+	exit 1
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+	echo "error: tmux command not found" >&2
+	exit 1
+fi
+
 NEW_SESSION="${usage_new:-false}"
 PWD_REAL="$(pwd -P)"
 DIR_NAME="$(basename "${PWD_REAL}")"

--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -17,7 +17,7 @@ hash_pwd() {
 }
 
 sanitize_tmux_name() {
-	printf '%s' "$1" |
+	printf '%s' "${1}" |
 		tr -cs '[:alnum:]_.-' '-' |
 		sed 's/^-//; s/-$//'
 }
@@ -27,21 +27,19 @@ _hash="$(hash_pwd)"
 BASE_NAME="codex-${_dir_safe}-${_hash}"
 SESSION_NAME="${BASE_NAME}"
 
-if [[ ${NEW_SESSION} == "true" ]]; then
+if [[ "${NEW_SESSION}" == "true" ]]; then
 	SESSION_NAME="${BASE_NAME}-$(date +%Y%m%d%H%M%S)-$$"
 elif tmux has-session -t "=${SESSION_NAME}" 2>/dev/null; then
-	if [[ -n ${TMUX:-} ]]; then
+	if [[ -n "${TMUX:-}" ]]; then
 		exec tmux switch-client -t "=${SESSION_NAME}"
 	else
 		exec tmux attach-session -t "=${SESSION_NAME}"
 	fi
 fi
 
-CODEX_CMD="cd $(printf '%q' "${PWD_REAL}") && exec codex"
-
-if [[ -n ${TMUX:-} ]]; then
-	tmux new-session -d -s "${SESSION_NAME}" bash -c "${CODEX_CMD}"
+if [[ -n "${TMUX:-}" ]]; then
+	tmux new-session -d -s "${SESSION_NAME}" -c "${PWD_REAL}" codex
 	exec tmux switch-client -t "=${SESSION_NAME}"
 else
-	exec tmux new-session -s "${SESSION_NAME}" bash -c "${CODEX_CMD}"
+	exec tmux new-session -s "${SESSION_NAME}" -c "${PWD_REAL}" codex
 fi

--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#MISE description "Launch Codex CLI in a tmux session scoped to the current directory"
+#USAGE flag "-n --new" help="Force creation of a new tmux session instead of attaching to the existing one for this directory"
+
+set -euo pipefail
+
+NEW_SESSION="${usage_new:-false}"
+PWD_REAL="$(pwd -P)"
+DIR_NAME="$(basename "$PWD_REAL")"
+
+hash_pwd() {
+	if command -v sha1sum >/dev/null 2>&1; then
+		printf '%s' "$PWD_REAL" | sha1sum | awk '{print substr($1,1,10)}'
+	else
+		printf '%s' "$PWD_REAL" | shasum -a 1 | awk '{print substr($1,1,10)}'
+	fi
+}
+
+sanitize_tmux_name() {
+	printf '%s' "$1" \
+		| tr -cs '[:alnum:]_.-' '-' \
+		| sed 's/^-//; s/-$//'
+}
+
+BASE_NAME="codex-$(sanitize_tmux_name "$DIR_NAME")-$(hash_pwd)"
+SESSION_NAME="$BASE_NAME"
+
+if [[ "$NEW_SESSION" == "true" ]]; then
+	SESSION_NAME="${BASE_NAME}-$(date +%Y%m%d%H%M%S)-$$"
+elif tmux has-session -t "=${SESSION_NAME}" 2>/dev/null; then
+	if [[ -n "${TMUX:-}" ]]; then
+		exec tmux switch-client -t "=${SESSION_NAME}"
+	else
+		exec tmux attach-session -t "=${SESSION_NAME}"
+	fi
+fi
+
+CODEX_CMD="cd $(printf '%q' "$PWD_REAL") && exec codex"
+
+if [[ -n "${TMUX:-}" ]]; then
+	tmux new-session -d -s "$SESSION_NAME" bash -c "$CODEX_CMD"
+	exec tmux switch-client -t "=${SESSION_NAME}"
+else
+	exec tmux new-session -s "$SESSION_NAME" bash -c "$CODEX_CMD"
+fi

--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -17,18 +17,18 @@ hash_pwd() {
 }
 
 sanitize_tmux_name() {
-	printf '%s' "$1" \
-		| tr -cs '[:alnum:]_.-' '-' \
-		| sed 's/^-//; s/-$//'
+	printf '%s' "$1" |
+		tr -cs '[:alnum:]_.-' '-' |
+		sed 's/^-//; s/-$//'
 }
 
 BASE_NAME="codex-$(sanitize_tmux_name "$DIR_NAME")-$(hash_pwd)"
 SESSION_NAME="$BASE_NAME"
 
-if [[ "$NEW_SESSION" == "true" ]]; then
+if [[ $NEW_SESSION == "true" ]]; then
 	SESSION_NAME="${BASE_NAME}-$(date +%Y%m%d%H%M%S)-$$"
 elif tmux has-session -t "=${SESSION_NAME}" 2>/dev/null; then
-	if [[ -n "${TMUX:-}" ]]; then
+	if [[ -n ${TMUX:-} ]]; then
 		exec tmux switch-client -t "=${SESSION_NAME}"
 	else
 		exec tmux attach-session -t "=${SESSION_NAME}"
@@ -37,7 +37,7 @@ fi
 
 CODEX_CMD="cd $(printf '%q' "$PWD_REAL") && exec codex"
 
-if [[ -n "${TMUX:-}" ]]; then
+if [[ -n ${TMUX:-} ]]; then
 	tmux new-session -d -s "$SESSION_NAME" bash -c "$CODEX_CMD"
 	exec tmux switch-client -t "=${SESSION_NAME}"
 else

--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -27,10 +27,10 @@ _hash="$(hash_pwd)"
 BASE_NAME="codex-${_dir_safe}-${_hash}"
 SESSION_NAME="${BASE_NAME}"
 
-if [[ "${NEW_SESSION}" == "true" ]]; then
+if [[ ${NEW_SESSION} == "true" ]]; then
 	SESSION_NAME="${BASE_NAME}-$(date +%Y%m%d%H%M%S)-$$"
 elif tmux has-session -t "=${SESSION_NAME}" 2>/dev/null; then
-	if [[ -n "${TMUX:-}" ]]; then
+	if [[ -n ${TMUX:-} ]]; then
 		exec tmux switch-client -t "=${SESSION_NAME}"
 	else
 		exec tmux attach-session -t "=${SESSION_NAME}"
@@ -39,7 +39,7 @@ fi
 
 CODEX_CMD="cd $(printf '%q' "${PWD_REAL}") && exec codex"
 
-if [[ -n "${TMUX:-}" ]]; then
+if [[ -n ${TMUX:-} ]]; then
 	tmux new-session -d -s "${SESSION_NAME}" bash -c "${CODEX_CMD}"
 	exec tmux switch-client -t "=${SESSION_NAME}"
 else

--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -6,13 +6,13 @@ set -euo pipefail
 
 NEW_SESSION="${usage_new:-false}"
 PWD_REAL="$(pwd -P)"
-DIR_NAME="$(basename "$PWD_REAL")"
+DIR_NAME="$(basename "${PWD_REAL}")"
 
 hash_pwd() {
 	if command -v sha1sum >/dev/null 2>&1; then
-		printf '%s' "$PWD_REAL" | sha1sum | awk '{print substr($1,1,10)}'
+		printf '%s' "${PWD_REAL}" | sha1sum | awk '{print substr($1,1,10)}'
 	else
-		printf '%s' "$PWD_REAL" | shasum -a 1 | awk '{print substr($1,1,10)}'
+		printf '%s' "${PWD_REAL}" | shasum -a 1 | awk '{print substr($1,1,10)}'
 	fi
 }
 
@@ -22,24 +22,26 @@ sanitize_tmux_name() {
 		sed 's/^-//; s/-$//'
 }
 
-BASE_NAME="codex-$(sanitize_tmux_name "$DIR_NAME")-$(hash_pwd)"
-SESSION_NAME="$BASE_NAME"
+_dir_safe="$(sanitize_tmux_name "${DIR_NAME}")"
+_hash="$(hash_pwd)"
+BASE_NAME="codex-${_dir_safe}-${_hash}"
+SESSION_NAME="${BASE_NAME}"
 
-if [[ $NEW_SESSION == "true" ]]; then
+if [[ "${NEW_SESSION}" == "true" ]]; then
 	SESSION_NAME="${BASE_NAME}-$(date +%Y%m%d%H%M%S)-$$"
 elif tmux has-session -t "=${SESSION_NAME}" 2>/dev/null; then
-	if [[ -n ${TMUX:-} ]]; then
+	if [[ -n "${TMUX:-}" ]]; then
 		exec tmux switch-client -t "=${SESSION_NAME}"
 	else
 		exec tmux attach-session -t "=${SESSION_NAME}"
 	fi
 fi
 
-CODEX_CMD="cd $(printf '%q' "$PWD_REAL") && exec codex"
+CODEX_CMD="cd $(printf '%q' "${PWD_REAL}") && exec codex"
 
-if [[ -n ${TMUX:-} ]]; then
-	tmux new-session -d -s "$SESSION_NAME" bash -c "$CODEX_CMD"
+if [[ -n "${TMUX:-}" ]]; then
+	tmux new-session -d -s "${SESSION_NAME}" bash -c "${CODEX_CMD}"
 	exec tmux switch-client -t "=${SESSION_NAME}"
 else
-	exec tmux new-session -s "$SESSION_NAME" bash -c "$CODEX_CMD"
+	exec tmux new-session -s "${SESSION_NAME}" bash -c "${CODEX_CMD}"
 fi


### PR DESCRIPTION
Adds global mise file task `codex-tmux`: directory-scoped tmux session name, reuse/attach vs `-n`/`--new`, and `bash -c` so `cd` + `exec codex` run correctly inside tmux.

Installed under `wsl/home/.config/mise/tasks/` and symlinked by the existing WSL home sync. Split from the npm Codex tooling PR per PLAN.

Made with [Cursor](https://cursor.com)