### PR TITLE
chore(bash): enable usage CLI completion

### DIFF
--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -129,6 +129,14 @@ if command -v ghr &>/dev/null; then
 	eval "${ghr_completion}"
 fi
 
+# Enable usage CLI completion (hk and other usage-based CLIs invoke `usage complete-word`; needs `_comp*`
+# from mise’s `completion bash --include-bash-completion-lib` above)
+# ref: https://usage.jdx.dev
+if command -v usage &>/dev/null; then
+	usage_completion="$(usage generate completion bash usage --usage-cmd 'usage --usage-spec')"
+	eval "${usage_completion}"
+fi
+
 # ref: https://hk.jdx.dev/cli/completion.html — requires `usage` on PATH (mise installs it globally)
 if command -v hk &>/dev/null; then
 	hk_completion="$(hk completion bash)"


### PR DESCRIPTION
## Summary

Evaluates the Bash completion script emitted by `usage generate completion bash usage --usage-cmd 'usage --usage-spec'` so the `usage` binary itself gets programmable completion (distinct from tools like `hk` that call `usage complete-word` internally).

## Placement

Inserted after **mise** completion and immediately before **hk** completion: mise’s `completion bash --include-bash-completion-lib` provides the `_comp_*` helpers this generator expects on Ubuntu WSL’s older system bash-completion.

## Reference

- https://usage.jdx.dev


Made with [Cursor](https://cursor.com)