### PR TITLE
fix(mise): run codex-tmux in the caller's cwd

### DIFF
--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description "Launch Codex CLI in a tmux session scoped to the current directory"
+#MISE dir="{{cwd}}"
 #USAGE flag "-n --new" help="Force creation of a new tmux session instead of attaching to the existing one for this directory"
 
 set -euo pipefail


### PR DESCRIPTION
## Summary

mise runs file tasks from `config_root` by default (for global config that is `~`), so `pwd` inside `codex-tmux` was the home directory. That broke tmux `-c` and directory-scoped session names when launching from a project directory.

## Change

Add `#MISE dir="{{cwd}}"` to the task script header so the task executes in the shell's current directory, matching [mise file tasks — CWD](https://mise.jdx.dev/tasks/file-tasks.html#cwd).

## Notes

- The template variable is `{{cwd}}`, not `current_dir`.
- Alternative would be `cd "$MISE_ORIGINAL_CWD"`; `dir="{{cwd}}"` keeps the whole script consistently in the right directory.

Made with [Cursor](https://cursor.com)