### PR TITLE
feat(tmux): add XDG config for Codex sessions

### DIFF
--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -49,8 +49,8 @@ elif tmux has-session -t "=${SESSION_NAME}" 2>/dev/null; then
 fi
 
 if [[ -n ${TMUX:-} ]]; then
-	tmux new-session -d -s "${SESSION_NAME}" -c "${PWD_REAL}" codex
+	tmux new-session -d -s "${SESSION_NAME}" -c "${PWD_REAL}" codex --disable terminal_resize_reflow
 	exec tmux switch-client -t "=${SESSION_NAME}"
 else
-	exec tmux new-session -s "${SESSION_NAME}" -c "${PWD_REAL}" codex
+	exec tmux new-session -s "${SESSION_NAME}" -c "${PWD_REAL}" codex --disable terminal_resize_reflow
 fi

--- a/wsl/home/.config/tmux/tmux.conf
+++ b/wsl/home/.config/tmux/tmux.conf
@@ -1,0 +1,5 @@
+set -g mouse on
+
+set -g status-left-length 80
+set -g status-left '#[bold]#{b:pane_current_path}#[default] #(git -C "#{pane_current_path}" branch --show-current 2>/dev/null | sed "s/^/[/" | sed "s/$/]/") '
+set -g status-right ''


### PR DESCRIPTION
## Summary
- add XDG tmux config under wsl/home/.config/tmux
- enable mouse support for TUI scrolling
- show current pane directory basename and Git branch in the status line
- clear the default date/time status-right
- disable Codex terminal resize reflow in the tmux launcher to avoid duplicated incremental redraws

## Verification
- tmux config loaded successfully on an isolated tmux socket
- symlink created at ~/.config/tmux/tmux.conf for local debugging
- bash -n wsl/home/.config/mise/tasks/codex-tmux