### PR TITLE
fix(wsl): stream cargo wrapper output

### DIFF
--- a/wsl/home/.local/bin/cargo
+++ b/wsl/home/.local/bin/cargo
@@ -11,7 +11,7 @@ run_limited() {
 		printf '%s\n' 'cargo wrapper: sem not found (apt install parallel)' >&2
 		exit 127
 	fi
-	sem --id "${SEM_ID}" -j 3 --fg -- "${REAL_CARGO}" "$@"
+	sem --id "${SEM_ID}" -j 3 --ungroup --fg -- "${REAL_CARGO}" "$@"
 }
 
 if [[ ! -x ${REAL_CARGO} ]]; then


### PR DESCRIPTION
## Summary
- pass `--ungroup` to GNU sem in the cargo wrapper so cargo diagnostics stream while the build is running

## Cause
GNU Parallel/sem defaults to grouped output, which buffers each foreground job output until it exits. That made long-running `cargo build` invocations appear silent even though cargo was producing diagnostics.

## Verification
- `shellcheck --external-sources wsl/home/.local/bin/cargo`
- `LINT=true mise run check:shfmt`
- `LINT=true mise run check:shellcheck`
- reproduced streaming behavior with a temporary REAL_CARGO shim that prints before and after a sleep
