### PR TITLE
chore(mise): use deps for bun installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Clone this repository and run the following command:
 
 ```bash
 mise i
+mise deps
 ```
 
 ### 🧵 Lint and Format

--- a/mise.toml
+++ b/mise.toml
@@ -38,6 +38,17 @@ experimental = true
 [settings.npm]
 package_manager = "aube"
 
+[deps.bun]
+auto = true
+run = "bun install --frozen-lockfile"
+
+[deps.bun-worker]
+auto = true
+dir = "worker"
+sources = ["package.json", "bun.lock"]
+outputs = ["node_modules"]
+run = "bun install --frozen-lockfile"
+
 [task_config]
 includes = ["tasks.toml", "tasks", "worker/tasks.toml", "worker/tasks"]
 

--- a/mise.toml
+++ b/mise.toml
@@ -40,6 +40,8 @@ package_manager = "aube"
 
 [deps.bun]
 auto = true
+sources = ["package.json", "bun.lock"]
+outputs = ["node_modules"]
 run = "bun install --frozen-lockfile"
 
 [deps.bun-worker]

--- a/mise.toml
+++ b/mise.toml
@@ -55,6 +55,6 @@ includes = ["tasks.toml", "tasks", "worker/tasks.toml", "worker/tasks"]
 [hooks]
 postinstall = """
 {% if env.CI is undefined %}
-  mise run buni ::: install:ps-script-analyzer
+  mise run --no-deps install:ps-script-analyzer
 {% endif %}
 """

--- a/tasks.toml
+++ b/tasks.toml
@@ -128,11 +128,11 @@ env.GITHUB_TOKEN = "{{ env.GITHUB_TOKEN }}"
 description = "Generate/update .gitignore from .gitignore-sync."
 
 ["buni"]
-depends = ["buni:root", "buni:worker"]
+run = "mise deps"
 description = "Install Bun dependencies."
 
 ["buni:root"]
-run = "bun install --frozen-lockfile"
+run = "mise deps bun"
 hide = true
 description = "Install Bun dependencies in the root directory."
 

--- a/tasks.toml
+++ b/tasks.toml
@@ -18,13 +18,11 @@ depends = ["check:tsc:*"]
 description = "Run TypeScript compiler to check types."
 
 ["check:tsc:root"]
-depends = ["buni:root"]
 run = "bun run tsc {% if env.CI is defined %}--incremental false{% endif %}"
 description = "Run TypeScript compiler to check types in the root directory."
 
 ["check:jsonschema"]
 # schema of wrangler.jsonc is in node_modules
-depends = ["buni:worker"]
 run = "jschema-validator"
 env.GITHUB_TOKEN = "{{ env.GITHUB_TOKEN }}"
 description = "Validate JSON/JSONC/JSON5 files with JSON schema."
@@ -126,15 +124,6 @@ depends_post = [
 ]
 env.GITHUB_TOKEN = "{{ env.GITHUB_TOKEN }}"
 description = "Generate/update .gitignore from .gitignore-sync."
-
-["buni"]
-run = "mise deps"
-description = "Install Bun dependencies."
-
-["buni:root"]
-run = "mise deps bun"
-hide = true
-description = "Install Bun dependencies in the root directory."
 
 ["install:ps-script-analyzer"]
 shell = "pwsh -Command"

--- a/worker/tasks.toml
+++ b/worker/tasks.toml
@@ -6,7 +6,6 @@ depends = ["check:tsc:worker:*"]
 description = "Run TypeScript compiler to check types in the worker directory."
 
 ["check:tsc:worker:base"]
-depends = ["buni:worker"]
 run = "bun run tsc --project tsconfig.base.json {% if env.CI is defined %}--incremental false{% endif %}"
 dir = "worker"
 description = "Run TypeScript compiler to check types in the worker directory (base)."
@@ -41,13 +40,7 @@ run = "bun run vitest {% if env.CI is undefined %}watch --ui{% else %}run{% endi
 dir = "worker"
 description = "Run tests for the worker."
 
-["buni:worker"]
-run = "mise deps bun-worker"
-hide = true
-description = "Install Bun dependencies in the worker directory."
-
 ["worker:generate:types"]
-depends = ["buni:worker"]
 run = "bun run wrangler types src/worker-configuration.d.ts"
 dir = "worker"
 hide = true

--- a/worker/tasks.toml
+++ b/worker/tasks.toml
@@ -42,8 +42,7 @@ dir = "worker"
 description = "Run tests for the worker."
 
 ["buni:worker"]
-run = "bun install --frozen-lockfile"
-dir = "worker"
+run = "mise deps bun-worker"
 hide = true
 description = "Install Bun dependencies in the worker directory."
 

--- a/worker/tasks/worker/build
+++ b/worker/tasks/worker/build
@@ -2,7 +2,6 @@
 #MISE description="Build the worker for production."
 #MISE hide=true
 #MISE dir="worker"
-#MISE depends=["buni:worker"]
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- configure mise deps providers for root and worker Bun installs
- keep buni task names as compatibility wrappers around mise deps

## Verification
- PATH=/home/risu/.local/share/mise/installs/aqua-jdx-mise/2026.5.4/mise/bin:$PATH mise deps --list
- PATH=/home/risu/.local/share/mise/installs/aqua-jdx-mise/2026.5.4/mise/bin:$PATH mise task validate
- PATH=/home/risu/.local/share/mise/installs/aqua-jdx-mise/2026.5.4/mise/bin:$PATH mise task run --dry-run buni:root
- PATH=/home/risu/.local/share/mise/installs/aqua-jdx-mise/2026.5.4/mise/bin:$PATH mise task run --dry-run buni:worker