### PR TITLE
feat(hk): switch type checks to tsgo

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@risu729/tsconfigs": "3.0.0",
         "@types/bun": "1.3.13",
+        "@typescript/native-preview": "7.0.0-dev.20260510.1",
         "jschema-validator": "1.0.27",
         "typescript": "6.0.3",
       },
@@ -20,6 +21,22 @@
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260510.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260510.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260510.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260510.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260510.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260510.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260510.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260510.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-05U6/Im+vmqGrFAVrHSeuoXBCwShhbiA+93VpSwEBYP4LMWk2JW9q87MydamL5g6ISEjIVlwQ4Dx35CauPAwpA=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260510.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YpG99bf/Va1aLGP8SUQy1ClUvi4c6uTFrEQ0B5KzZb9TsOwH1RIrc/2n8UO3IAuilvwEA0EU4q8fEO3otVP2Sw=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260510.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-NUwhwHpQn7aSX2GGBuY2bjec+hFnIz2DAna4ksVneexVE20h2U0MFzBvWrqH2C0PzPxVvGOMg4fGCvhTs93nlw=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260510.1", "", { "os": "linux", "cpu": "arm" }, "sha512-UE+PIWWg7vvszSU0gS9rzgIIHCWexz3hMZDHpHRSLAleAvULCNI3EzwTRFOA4BHyQ8eReD1KZ8e76BuStEPspw=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260510.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-T7Zuy6h0sU+38w+N3A+YgW0XVqxIMjeHyu+945rJkiP9zk52Mwp663t1ndyeAE/N2zV+q0SWQmHNuFSXl99wJw=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260510.1", "", { "os": "linux", "cpu": "x64" }, "sha512-gJu4q4YREvjR2Lx1jUaCd/bRbTuyKf2r3rJ4tReuHyAvNse23HdGI0a9w4Z3wUbvRznxYt640IIItWsr/f3LEQ=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260510.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-00DtjrtkdAHOU/soYr8ncrjUvIsple8nvb29ZUATnLraNnzUgv5AS3yMve/pG/N7rVLlKy2FrXlVyVW7WAx29w=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260510.1", "", { "os": "win32", "cpu": "x64" }, "sha512-27UeujQTEPFxhfkZL7aHnA1TlNol3nwDVFp5d6jFoP14yTXMe47kBnAJLEU2ta3REZE5PzLCs7HLV8H4VdxGgA=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -2,7 +2,15 @@ amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.
 import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
 
 local const jsTsTypes = List("javascript", "typescript")
-local const bashrcGlob = List("wsl/home/.bashrc")
+local const shellGlobs = List(
+  "tasks/**",
+  "worker/docker/entrypoint.sh",
+  "worker/tasks/**",
+  "wsl/home/.bashrc",
+  "wsl/home/.config/mise/tasks/**",
+  "wsl/home/.local/bin/**",
+  "wsl/install.sh",
+)
 
 local const lintSteps = new Mapping<String, Step> {
   ["oxlint"] = (Builtins.ox_lint) {
@@ -51,33 +59,18 @@ local const lintSteps = new Mapping<String, Step> {
     fix = "markdownlint-cli2 --fix {{ files }}"
   }
   ["shfmt"] {
-    types = List("shell")
+    glob = shellGlobs
     batch = false
-    check_diff = "shfmt --diff --simplify {{ files }}"
-    fix = "shfmt --write --simplify {{ files }}"
-  }
-  ["shfmt:bashrc"] {
-    glob = bashrcGlob
     check_diff = "shfmt --diff --simplify {{ files }}"
     fix = "shfmt --write --simplify {{ files }}"
   }
   ["shellcheck"] {
-    types = List("shell")
+    glob = shellGlobs
     batch = false
     check = "shellcheck --external-sources {{ files }}"
   }
-  ["shellcheck:bashrc"] {
-    glob = bashrcGlob
-    check = "shellcheck --external-sources {{ files }}"
-  }
-  ["install:ps-script-analyzer"] {
-    glob = List("win/**/*.ps1")
-    check = "mise run --no-deps install:ps-script-analyzer"
-    hide = true
-  }
   ["pwsh"] {
     glob = List("win/**/*.ps1")
-    depends = "install:ps-script-analyzer"
     check = "pwsh -Command 'Invoke-ScriptAnalyzer -Path win -Recurse -EnableExit -Settings win/PSScriptAnalyzerSettings.psd1'"
   }
   ["yamlfmt"] = (Builtins.yamlfmt) {

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,30 +1,54 @@
 amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
 
-local const jsTsTypes = List("javascript", "typescript")
-local const shellGlobs = List(
-  "tasks/**",
-  "worker/docker/entrypoint.sh",
-  "worker/tasks/**",
-  "wsl/home/.bashrc",
-  "wsl/home/.config/mise/tasks/**",
-  "wsl/home/.local/bin/**",
-  "wsl/install.sh",
-)
+fail_fast = false
+
+local const jsTsGlobs =
+  List(
+    "**/*.js",
+    "**/*.mjs",
+    "**/*.cjs",
+    "**/*.ts",
+    "**/*.mts",
+    "**/*.cts",
+    "**/*.jsx",
+    "**/*.tsx",
+    "**/*.vue",
+    "**/*.svelte",
+    "**/*.astro",
+  )
+
+local const lycheeGlobs =
+  List(
+    "**/*.md",
+    "**/*.mkd",
+    "**/*.mdx",
+    "**/*.mdown",
+    "**/*.mdwn",
+    "**/*.mkdn",
+    "**/*.mkdown",
+    "**/*.markdown",
+    "**/*.html",
+    "**/*.htm",
+    "**/*.css",
+    "**/*.txt",
+    "**/*.xml",
+  )
 
 local const lintSteps = new Mapping<String, Step> {
   ["oxlint"] = (Builtins.ox_lint) {
-    types = jsTsTypes
-    check = "oxlint --no-error-on-unmatched-pattern --report-unused-disable-directives-severity error {{ files }}"
-    fix = "oxlint --no-error-on-unmatched-pattern --report-unused-disable-directives-severity error --fix {{ files }}"
+    glob = jsTsGlobs
+    check = "oxlint --report-unused-disable-directives-severity error {{ files }}"
+    fix = "oxlint --report-unused-disable-directives-severity error --fix {{ files }}"
   }
   ["oxfmt"] {
     types = List("javascript", "typescript", "json", "markdown")
+    batch = true
     check = "oxfmt --check {{ files }}"
+    check_list_files = "oxfmt --list-different {{ files }}"
     fix = "oxfmt {{ files }}"
   }
   ["actionlint"] = (Builtins.actionlint) {
-    batch = false
     check = "actionlint -color {{ files }}"
     env {
       ["SHELLCHECK_OPTS"] = "--enable=all --exclude=SC2312"
@@ -59,19 +83,46 @@ local const lintSteps = new Mapping<String, Step> {
     fix = "markdownlint-cli2 --fix {{ files }}"
   }
   ["shfmt"] {
-    glob = shellGlobs
-    batch = false
+    types = List("shell")
+    batch = true
     check_diff = "shfmt --diff --simplify {{ files }}"
+    check_list_files =
+      """
+      files=$(shfmt --list --simplify {{ files }})
+      if [ -n "$files" ]; then
+        echo "$files"
+        exit 1
+      fi
+      """
+    fix = "shfmt --write --simplify {{ files }}"
+  }
+  ["shfmt-bashrc"] {
+    glob = "wsl/home/.bashrc"
+    check_diff = "shfmt --diff --simplify {{ files }}"
+    check_list_files =
+      """
+      files=$(shfmt --list --simplify {{ files }})
+      if [ -n "$files" ]; then
+        echo "$files"
+        exit 1
+      fi
+      """
     fix = "shfmt --write --simplify {{ files }}"
   }
   ["shellcheck"] {
-    glob = shellGlobs
-    batch = false
+    types = List("shell")
+    batch = true
+    check = "shellcheck --external-sources {{ files }}"
+  }
+  ["shellcheck-bashrc"] {
+    glob = "wsl/home/.bashrc"
     check = "shellcheck --external-sources {{ files }}"
   }
   ["pwsh"] {
-    glob = List("win/**/*.ps1")
-    check = "pwsh -Command 'Invoke-ScriptAnalyzer -Path win -Recurse -EnableExit -Settings win/PSScriptAnalyzerSettings.psd1'"
+    glob = List("win/**/*.ps1", "win/**/*.psd1", "win/**/*.psm1")
+    shell = "pwsh -Command"
+    check = "Invoke-ScriptAnalyzer -Path . -Recurse -EnableExit -Settings PSScriptAnalyzerSettings.psd1"
+    dir = "win"
   }
   ["yamlfmt"] = (Builtins.yamlfmt) {
     types = List("yaml")
@@ -87,8 +138,9 @@ local const lintSteps = new Mapping<String, Step> {
     check = "mise fmt --check && mise task validate"
     fix = "mise fmt && mise task validate"
   }
-  ["lychee"] = (Builtins.lychee) {
-    check = "lychee --no-progress --verbose {{ files }}"
+  ["lychee"] {
+    glob = lycheeGlobs
+    check = "lychee --verbose {{ files }}"
   }
   ["typos"] = Builtins.typos
   ["ignore-sync"] {
@@ -99,16 +151,16 @@ local const lintSteps = new Mapping<String, Step> {
     exclusive = true
   }
   ["jsonschema"] {
-    types = List("json")
+    glob = List("**/*.json", "**/*.jsonc", "**/*.json5")
     check = "jschema-validator"
   }
   ["tsc:root"] {
-    types = jsTsTypes
+    glob = jsTsGlobs
     check = "bun run tsc"
     profiles = List("!ci")
   }
   ["tsc:root:ci"] {
-    types = jsTsTypes
+    glob = jsTsGlobs
     check = "bun run tsc --incremental false"
     profiles = List("ci")
   }
@@ -118,40 +170,40 @@ local const lintSteps = new Mapping<String, Step> {
     hide = true
   }
   ["worker:tsc:base"] {
-    types = jsTsTypes
+    glob = jsTsGlobs
     check = "bun run tsc --project tsconfig.base.json"
     dir = "worker"
     profiles = List("!ci")
   }
   ["worker:tsc:base:ci"] {
-    types = jsTsTypes
+    glob = jsTsGlobs
     check = "bun run tsc --project tsconfig.base.json --incremental false"
     dir = "worker"
     profiles = List("ci")
   }
   ["worker:tsc:src"] {
-    types = jsTsTypes
+    glob = jsTsGlobs
     check = "bun run tsc --project tsconfig.src.json"
     dir = "worker"
     depends = "worker:generate-types"
     profiles = List("!ci")
   }
   ["worker:tsc:src:ci"] {
-    types = jsTsTypes
+    glob = jsTsGlobs
     check = "bun run tsc --project tsconfig.src.json --incremental false"
     dir = "worker"
     depends = "worker:generate-types"
     profiles = List("ci")
   }
   ["worker:tsc:test"] {
-    types = jsTsTypes
+    glob = jsTsGlobs
     check = "bun run tsc --project tsconfig.test.json"
     dir = "worker"
     depends = "worker:generate-types"
     profiles = List("!ci")
   }
   ["worker:tsc:test:ci"] {
-    types = jsTsTypes
+    glob = jsTsGlobs
     check = "bun run tsc --project tsconfig.test.json --incremental false"
     dir = "worker"
     depends = "worker:generate-types"

--- a/hk.pkl
+++ b/hk.pkl
@@ -109,14 +109,14 @@ local const lintSteps = new Mapping<String, Step> {
     types = List("json")
     check = "jschema-validator"
   }
-  ["tsc:root"] {
+  ["tsgo:root"] {
     types = jsTsTypes
-    check = "bun run tsc"
+    check = "bun run tsgo"
     profiles = List("!ci")
   }
-  ["tsc:root:ci"] {
+  ["tsgo:root:ci"] {
     types = jsTsTypes
-    check = "bun run tsc --incremental false"
+    check = "bun run tsgo --incremental false"
     profiles = List("ci")
   }
   ["worker:generate-types"] {
@@ -124,42 +124,42 @@ local const lintSteps = new Mapping<String, Step> {
     dir = "worker"
     hide = true
   }
-  ["worker:tsc:base"] {
+  ["worker:tsgo:base"] {
     types = jsTsTypes
-    check = "bun run tsc --project tsconfig.base.json"
+    check = "bun run tsgo --project tsconfig.base.json"
     dir = "worker"
     profiles = List("!ci")
   }
-  ["worker:tsc:base:ci"] {
+  ["worker:tsgo:base:ci"] {
     types = jsTsTypes
-    check = "bun run tsc --project tsconfig.base.json --incremental false"
+    check = "bun run tsgo --project tsconfig.base.json --incremental false"
     dir = "worker"
     profiles = List("ci")
   }
-  ["worker:tsc:src"] {
+  ["worker:tsgo:src"] {
     types = jsTsTypes
-    check = "bun run tsc --project tsconfig.src.json"
+    check = "bun run tsgo --project tsconfig.src.json"
     dir = "worker"
     depends = "worker:generate-types"
     profiles = List("!ci")
   }
-  ["worker:tsc:src:ci"] {
+  ["worker:tsgo:src:ci"] {
     types = jsTsTypes
-    check = "bun run tsc --project tsconfig.src.json --incremental false"
+    check = "bun run tsgo --project tsconfig.src.json --incremental false"
     dir = "worker"
     depends = "worker:generate-types"
     profiles = List("ci")
   }
-  ["worker:tsc:test"] {
+  ["worker:tsgo:test"] {
     types = jsTsTypes
-    check = "bun run tsc --project tsconfig.test.json"
+    check = "bun run tsgo --project tsconfig.test.json"
     dir = "worker"
     depends = "worker:generate-types"
     profiles = List("!ci")
   }
-  ["worker:tsc:test:ci"] {
+  ["worker:tsgo:test:ci"] {
     types = jsTsTypes
-    check = "bun run tsc --project tsconfig.test.json --incremental false"
+    check = "bun run tsgo --project tsconfig.test.json --incremental false"
     dir = "worker"
     depends = "worker:generate-types"
     profiles = List("ci")

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,54 +1,22 @@
 amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
 
-fail_fast = false
-
-local const jsTsGlobs =
-  List(
-    "**/*.js",
-    "**/*.mjs",
-    "**/*.cjs",
-    "**/*.ts",
-    "**/*.mts",
-    "**/*.cts",
-    "**/*.jsx",
-    "**/*.tsx",
-    "**/*.vue",
-    "**/*.svelte",
-    "**/*.astro",
-  )
-
-local const lycheeGlobs =
-  List(
-    "**/*.md",
-    "**/*.mkd",
-    "**/*.mdx",
-    "**/*.mdown",
-    "**/*.mdwn",
-    "**/*.mkdn",
-    "**/*.mkdown",
-    "**/*.markdown",
-    "**/*.html",
-    "**/*.htm",
-    "**/*.css",
-    "**/*.txt",
-    "**/*.xml",
-  )
+local const jsTsTypes = List("javascript", "typescript")
+local const bashrcGlob = List("wsl/home/.bashrc")
 
 local const lintSteps = new Mapping<String, Step> {
   ["oxlint"] = (Builtins.ox_lint) {
-    glob = jsTsGlobs
-    check = "oxlint --report-unused-disable-directives-severity error {{ files }}"
-    fix = "oxlint --report-unused-disable-directives-severity error --fix {{ files }}"
+    types = jsTsTypes
+    check = "oxlint --no-error-on-unmatched-pattern --report-unused-disable-directives-severity error {{ files }}"
+    fix = "oxlint --no-error-on-unmatched-pattern --report-unused-disable-directives-severity error --fix {{ files }}"
   }
   ["oxfmt"] {
     types = List("javascript", "typescript", "json", "markdown")
-    batch = true
     check = "oxfmt --check {{ files }}"
-    check_list_files = "oxfmt --list-different {{ files }}"
     fix = "oxfmt {{ files }}"
   }
   ["actionlint"] = (Builtins.actionlint) {
+    batch = false
     check = "actionlint -color {{ files }}"
     env {
       ["SHELLCHECK_OPTS"] = "--enable=all --exclude=SC2312"
@@ -84,45 +52,33 @@ local const lintSteps = new Mapping<String, Step> {
   }
   ["shfmt"] {
     types = List("shell")
-    batch = true
+    batch = false
     check_diff = "shfmt --diff --simplify {{ files }}"
-    check_list_files =
-      """
-      files=$(shfmt --list --simplify {{ files }})
-      if [ -n "$files" ]; then
-        echo "$files"
-        exit 1
-      fi
-      """
     fix = "shfmt --write --simplify {{ files }}"
   }
-  ["shfmt-bashrc"] {
-    glob = "wsl/home/.bashrc"
+  ["shfmt:bashrc"] {
+    glob = bashrcGlob
     check_diff = "shfmt --diff --simplify {{ files }}"
-    check_list_files =
-      """
-      files=$(shfmt --list --simplify {{ files }})
-      if [ -n "$files" ]; then
-        echo "$files"
-        exit 1
-      fi
-      """
     fix = "shfmt --write --simplify {{ files }}"
   }
   ["shellcheck"] {
     types = List("shell")
-    batch = true
+    batch = false
     check = "shellcheck --external-sources {{ files }}"
   }
-  ["shellcheck-bashrc"] {
-    glob = "wsl/home/.bashrc"
+  ["shellcheck:bashrc"] {
+    glob = bashrcGlob
     check = "shellcheck --external-sources {{ files }}"
+  }
+  ["install:ps-script-analyzer"] {
+    glob = List("win/**/*.ps1")
+    check = "mise run --no-deps install:ps-script-analyzer"
+    hide = true
   }
   ["pwsh"] {
-    glob = List("win/**/*.ps1", "win/**/*.psd1", "win/**/*.psm1")
-    shell = "pwsh -Command"
-    check = "Invoke-ScriptAnalyzer -Path . -Recurse -EnableExit -Settings PSScriptAnalyzerSettings.psd1"
-    dir = "win"
+    glob = List("win/**/*.ps1")
+    depends = "install:ps-script-analyzer"
+    check = "pwsh -Command 'Invoke-ScriptAnalyzer -Path win -Recurse -EnableExit -Settings win/PSScriptAnalyzerSettings.psd1'"
   }
   ["yamlfmt"] = (Builtins.yamlfmt) {
     types = List("yaml")
@@ -138,9 +94,8 @@ local const lintSteps = new Mapping<String, Step> {
     check = "mise fmt --check && mise task validate"
     fix = "mise fmt && mise task validate"
   }
-  ["lychee"] {
-    glob = lycheeGlobs
-    check = "lychee --verbose {{ files }}"
+  ["lychee"] = (Builtins.lychee) {
+    check = "lychee --no-progress --verbose {{ files }}"
   }
   ["typos"] = Builtins.typos
   ["ignore-sync"] {
@@ -151,16 +106,16 @@ local const lintSteps = new Mapping<String, Step> {
     exclusive = true
   }
   ["jsonschema"] {
-    glob = List("**/*.json", "**/*.jsonc", "**/*.json5")
+    types = List("json")
     check = "jschema-validator"
   }
   ["tsc:root"] {
-    glob = jsTsGlobs
+    types = jsTsTypes
     check = "bun run tsc"
     profiles = List("!ci")
   }
   ["tsc:root:ci"] {
-    glob = jsTsGlobs
+    types = jsTsTypes
     check = "bun run tsc --incremental false"
     profiles = List("ci")
   }
@@ -170,40 +125,40 @@ local const lintSteps = new Mapping<String, Step> {
     hide = true
   }
   ["worker:tsc:base"] {
-    glob = jsTsGlobs
+    types = jsTsTypes
     check = "bun run tsc --project tsconfig.base.json"
     dir = "worker"
     profiles = List("!ci")
   }
   ["worker:tsc:base:ci"] {
-    glob = jsTsGlobs
+    types = jsTsTypes
     check = "bun run tsc --project tsconfig.base.json --incremental false"
     dir = "worker"
     profiles = List("ci")
   }
   ["worker:tsc:src"] {
-    glob = jsTsGlobs
+    types = jsTsTypes
     check = "bun run tsc --project tsconfig.src.json"
     dir = "worker"
     depends = "worker:generate-types"
     profiles = List("!ci")
   }
   ["worker:tsc:src:ci"] {
-    glob = jsTsGlobs
+    types = jsTsTypes
     check = "bun run tsc --project tsconfig.src.json --incremental false"
     dir = "worker"
     depends = "worker:generate-types"
     profiles = List("ci")
   }
   ["worker:tsc:test"] {
-    glob = jsTsGlobs
+    types = jsTsTypes
     check = "bun run tsc --project tsconfig.test.json"
     dir = "worker"
     depends = "worker:generate-types"
     profiles = List("!ci")
   }
   ["worker:tsc:test:ci"] {
-    glob = jsTsGlobs
+    types = jsTsTypes
     check = "bun run tsc --project tsconfig.test.json --incremental false"
     dir = "worker"
     depends = "worker:generate-types"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"devDependencies": {
 		"@risu729/tsconfigs": "3.0.0",
 		"@types/bun": "1.3.13",
+		"@typescript/native-preview": "7.0.0-dev.20260510.1",
 		"jschema-validator": "1.0.27",
 		"typescript": "6.0.3"
 	}

--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -12,6 +12,7 @@
         "@cloudflare/vitest-pool-workers": "0.16.4",
         "@risu729/tsconfigs": "3.0.0",
         "@types/bun": "1.3.13",
+        "@typescript/native-preview": "7.0.0-dev.20260510.1",
         "@vitest/ui": "4.1.6",
         "diff": "9.0.0",
         "typescript": "6.0.3",
@@ -219,6 +220,22 @@
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260510.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260510.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260510.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260510.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260510.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260510.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260510.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260510.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-05U6/Im+vmqGrFAVrHSeuoXBCwShhbiA+93VpSwEBYP4LMWk2JW9q87MydamL5g6ISEjIVlwQ4Dx35CauPAwpA=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260510.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YpG99bf/Va1aLGP8SUQy1ClUvi4c6uTFrEQ0B5KzZb9TsOwH1RIrc/2n8UO3IAuilvwEA0EU4q8fEO3otVP2Sw=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260510.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-NUwhwHpQn7aSX2GGBuY2bjec+hFnIz2DAna4ksVneexVE20h2U0MFzBvWrqH2C0PzPxVvGOMg4fGCvhTs93nlw=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260510.1", "", { "os": "linux", "cpu": "arm" }, "sha512-UE+PIWWg7vvszSU0gS9rzgIIHCWexz3hMZDHpHRSLAleAvULCNI3EzwTRFOA4BHyQ8eReD1KZ8e76BuStEPspw=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260510.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-T7Zuy6h0sU+38w+N3A+YgW0XVqxIMjeHyu+945rJkiP9zk52Mwp663t1ndyeAE/N2zV+q0SWQmHNuFSXl99wJw=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260510.1", "", { "os": "linux", "cpu": "x64" }, "sha512-gJu4q4YREvjR2Lx1jUaCd/bRbTuyKf2r3rJ4tReuHyAvNse23HdGI0a9w4Z3wUbvRznxYt640IIItWsr/f3LEQ=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260510.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-00DtjrtkdAHOU/soYr8ncrjUvIsple8nvb29ZUATnLraNnzUgv5AS3yMve/pG/N7rVLlKy2FrXlVyVW7WAx29w=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260510.1", "", { "os": "win32", "cpu": "x64" }, "sha512-27UeujQTEPFxhfkZL7aHnA1TlNol3nwDVFp5d6jFoP14yTXMe47kBnAJLEU2ta3REZE5PzLCs7HLV8H4VdxGgA=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -13,6 +13,7 @@
 		"@cloudflare/vitest-pool-workers": "0.16.4",
 		"@risu729/tsconfigs": "3.0.0",
 		"@types/bun": "1.3.13",
+		"@typescript/native-preview": "7.0.0-dev.20260510.1",
 		"@vitest/ui": "4.1.6",
 		"diff": "9.0.0",
 		"typescript": "6.0.3",


### PR DESCRIPTION
## Summary
- switch the hk TypeScript check steps from `tsc` to `tsgo` via `@typescript/native-preview`
- keep the same hk profile split from #3344: local default profile uses incremental checks, while `--profile ci` runs the non-incremental commands
- leave TOML and Markdown linting unchanged for the follow-up stacked PRs

Stacked on #3344.

## Verification
- `mise x --no-deps -- hk validate`
- `mise x --no-deps -- hk --profile ci check --all --check --plan --json`
- `CI=true LINT=true GITHUB_TOKEN="${GITHUB_TOKEN:-}" mise run --no-deps check`
- `git diff --check`
