### PR TITLE
ci: limit mise lock autofix to renovate PRs

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -46,6 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Regenerate lockfiles
+        if: ${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/') }}
         run: mise lock --platform linux-x64
 
       - name: autofix.ci


### PR DESCRIPTION
## Summary
- run `mise lock --platform linux-x64` in autofix only for pull requests from `renovate/` branches
- keep the rest of autofix.ci running for all PRs

## Tests
- `actionlint -color .github/workflows/autofix.yml`
- `yamllint --strict .github/workflows/autofix.yml`
- `zizmor --pedantic .github/workflows/autofix.yml`
- `yamlfmt -lint .github/workflows/autofix.yml`
- `ghalint run`
- `git diff --check`