### PR TITLE
fix(tmux): pass through codex terminal notifications

### DIFF
--- a/wsl/home/.config/tmux/tmux.conf
+++ b/wsl/home/.config/tmux/tmux.conf
@@ -1,4 +1,8 @@
 set -g mouse on
+set -g focus-events on
+set -g set-titles on
+set -g set-titles-string '#{pane_title}'
+set -g allow-passthrough on
 
 set -g status-left-length 80
 set -g status-left '#[bold]#{b:pane_current_path}#[default] #(git -C "#{pane_current_path}" branch --show-current 2>/dev/null | sed "s/^/[/" | sed "s/$/]/") '


### PR DESCRIPTION
## Summary
- enable tmux focus events so Codex can observe terminal focus state
- propagate pane titles so Codex title/spinner updates reach the outer terminal
- enable tmux passthrough so Codex terminal notification escape sequences can reach Windows Terminal

## Why
Codex does not rely only on raw BEL. In `auto` mode it may emit OSC 9 terminal notifications, and its title/spinner behavior also uses terminal escape sequences. A plain `printf '\a'` can work in tmux while Codex notifications still fail because tmux is not passing the relevant Codex escape sequences through.

This follows the workaround confirmed in openai/codex#16855.

## Testing
- `tmux -L codex-config-parse-test -f wsl/home/.config/tmux/tmux.conf start-server \; show-options -g focus-events \; show-options -g set-titles \; show-options -g set-titles-string \; show-options -g allow-passthrough \; kill-server`
- `git diff --check origin/main`
- `mise run check:shfmt`
- `mise run check:shellcheck`
- `LINT=true mise run check:typos`
