### PR TITLE
ci: skip mise deps for metadata tasks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -90,10 +90,16 @@ jobs:
           restore-keys: cache-${{ matrix.name }}-
 
       - name: Run ${{ matrix.name }}
-        run: mise run "${TASK_NAME}"
+        run: |
+          mise_run_options=()
+          if [[ ${SKIP_DEPS} == 'true' ]]; then
+            mise_run_options+=(--no-deps)
+          fi
+          mise run "${mise_run_options[@]}" "${TASK_NAME}"
         env:
           LINT: true
           GITHUB_TOKEN: ${{ matrix.require_gh_token == 'true' && github.token || '' }}
+          SKIP_DEPS: ${{ matrix.skip_deps }}
           TASK_NAME: ${{ matrix.task }}
 
       - name: Save cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: List mise tasks
         id: list
-        run: mise run ci:list-tasks
+        run: mise run --no-deps ci:list-tasks
 
   lint:
     needs: list-tasks

--- a/.github/workflows/worker-docker.yml
+++ b/.github/workflows/worker-docker.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Retrieve worker Docker image info
         id: image-info
-        run: mise run ci:worker-docker:image-info
+        run: mise run --no-deps ci:worker-docker:image-info
         env:
           MISE_AUTO_INSTALL: false
           IMAGE_NAME: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/wsl-docker.yml
+++ b/.github/workflows/wsl-docker.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Retrieve Ubuntu WSL image info
         id: image-info
-        run: mise run ci:wsl-docker:image-info
+        run: mise run --no-deps ci:wsl-docker:image-info
         env:
           MISE_AUTO_INSTALL: false
           MISE_LOG_LEVEL: trace

--- a/tasks.toml
+++ b/tasks.toml
@@ -66,14 +66,14 @@ description = "Run markdownlint to lint Markdown files."
 # ref: https://github.com/mvdan/sh/issues/288
 run = """
 shfmt {% if env.LINT is undefined %}--list --write{% else %}--diff{% endif %} \
-	--simplify {{ exec(command='mise run util:list-scripts') }}"""
+	--simplify {{ exec(command='mise run --no-deps util:list-scripts') }}"""
 description = "Run shfmt to format shell scripts."
 
 ["check:shellcheck"]
 # recursive globbing is not supported
 # ref: https://www.shellcheck.net/wiki/Recursiveness
 # ref: https://github.com/koalaman/shellcheck/issues/143
-run = "shellcheck --external-sources {{ exec(command='mise run util:list-scripts') }}"
+run = "shellcheck --external-sources {{ exec(command='mise run --no-deps util:list-scripts') }}"
 description = "Run shellcheck to lint shell scripts."
 
 ["check:pwsh"]

--- a/tasks/ci/list-tasks
+++ b/tasks/ci/list-tasks
@@ -8,10 +8,12 @@ tasks=$(mise tasks ls --json)
 
 output=$(echo "${tasks}" | jq --raw-output --compact-output \
 	'map(select(.name | test("^check:[^:]+$"))
+		| .name as $task_name
 		| {
-			name: (.name | sub("^.+:" ; "")),
-			task: .name,
+			name: ($task_name | sub("^.+:" ; "")),
+			task: $task_name,
 			require_gh_token: any(.env[]; test("env\\.GITHUB_TOKEN")) | tostring,
+			skip_deps: ((["check:jsonschema", "check:tsc"] | index($task_name) | not) | tostring),
 			cache_path: ([.env[] | select(startswith("CACHE_PATH=")) | sub("^CACHE_PATH="; "")] | first // ""),
 		}
 	)')


### PR DESCRIPTION
## Summary
- add --no-deps to mise task discovery and Docker image metadata tasks
- generate a lint-matrix skip_deps flag so independent lint tasks skip automatic mise deps
- skip deps for the script-listing helper used by shfmt and shellcheck
- keep Bun package installs for tsc and jsonschema, which need node_modules

## Verification
- GITHUB_OUTPUT=/tmp/d2-list-tasks.out mise run --no-deps ci:list-tasks
- GITHUB_OUTPUT=/tmp/d2-worker-image-info.out IMAGE_NAME=risu729/dotfiles/worker GITHUB_TOKEN=$GITHUB_TOKEN mise run --no-deps ci:worker-docker:image-info
- GITHUB_OUTPUT=/tmp/d2-wsl-image-info.out IMAGE_NAME=risu729/dotfiles/wsl GITHUB_TOKEN=$GITHUB_TOKEN mise run --no-deps ci:wsl-docker:image-info
- mise run --no-deps check:actionlint
- mise run --no-deps check:ghalint
- LINT=true GITHUB_TOKEN=$GITHUB_TOKEN mise run --no-deps check:pinact
- GITHUB_TOKEN=$GITHUB_TOKEN mise run --no-deps check:zizmor
- mise run --no-deps check:yamlfmt
- mise run --no-deps check:shellcheck
- LINT=true mise run --no-deps check:shfmt
- LINT=true mise run --no-deps check:taplo
- mise run --no-deps check:mise
- git diff --check

Fixes Renovate mise update CI failures where jobs prepared Bun deps without needing them.