### PR TITLE
fix(hk): detect shell scripts by type

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -4,6 +4,9 @@ import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtin
 local const jsTsTypes = List("javascript", "typescript")
 local const shellTypes = List("shell")
 local const bashrcGlobs = List("wsl/home/.bashrc")
+local const shfmtCheck = "shfmt --diff --simplify {{ files }}"
+local const shfmtFix = "shfmt --write --simplify {{ files }}"
+local const shellcheckCheck = "shellcheck --external-sources {{ files }}"
 
 local const lintSteps = new Mapping<String, Step> {
   ["oxlint"] = (Builtins.ox_lint) {
@@ -54,26 +57,26 @@ local const lintSteps = new Mapping<String, Step> {
   ["shfmt"] {
     types = shellTypes
     batch = false
-    check_diff = "shfmt --diff --simplify {{ files }}"
-    fix = "shfmt --write --simplify {{ files }}"
+    check_diff = shfmtCheck
+    fix = shfmtFix
   }
   // hk narrows selection when both glob and types are set, so .bashrc needs
   // separate steps because it has no shell extension or shebang.
   ["shfmt:bashrc"] {
     glob = bashrcGlobs
     batch = false
-    check_diff = "shfmt --diff --simplify {{ files }}"
-    fix = "shfmt --write --simplify {{ files }}"
+    check_diff = shfmtCheck
+    fix = shfmtFix
   }
   ["shellcheck"] {
     types = shellTypes
     batch = false
-    check = "shellcheck --external-sources {{ files }}"
+    check = shellcheckCheck
   }
   ["shellcheck:bashrc"] {
     glob = bashrcGlobs
     batch = false
-    check = "shellcheck --external-sources {{ files }}"
+    check = shellcheckCheck
   }
   ["pwsh"] {
     glob = List("win/**/*.ps1")

--- a/hk.pkl
+++ b/hk.pkl
@@ -2,15 +2,8 @@ amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.
 import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
 
 local const jsTsTypes = List("javascript", "typescript")
-local const shellGlobs = List(
-  "tasks/**",
-  "worker/docker/entrypoint.sh",
-  "worker/tasks/**",
-  "wsl/home/.bashrc",
-  "wsl/home/.config/mise/tasks/**",
-  "wsl/home/.local/bin/**",
-  "wsl/install.sh",
-)
+local const shellTypes = List("shell")
+local const bashrcGlobs = List("wsl/home/.bashrc")
 
 local const lintSteps = new Mapping<String, Step> {
   ["oxlint"] = (Builtins.ox_lint) {
@@ -59,13 +52,26 @@ local const lintSteps = new Mapping<String, Step> {
     fix = "markdownlint-cli2 --fix {{ files }}"
   }
   ["shfmt"] {
-    glob = shellGlobs
+    types = shellTypes
+    batch = false
+    check_diff = "shfmt --diff --simplify {{ files }}"
+    fix = "shfmt --write --simplify {{ files }}"
+  }
+  // hk narrows selection when both glob and types are set, so .bashrc needs
+  // separate steps because it has no shell extension or shebang.
+  ["shfmt:bashrc"] {
+    glob = bashrcGlobs
     batch = false
     check_diff = "shfmt --diff --simplify {{ files }}"
     fix = "shfmt --write --simplify {{ files }}"
   }
   ["shellcheck"] {
-    glob = shellGlobs
+    types = shellTypes
+    batch = false
+    check = "shellcheck --external-sources {{ files }}"
+  }
+  ["shellcheck:bashrc"] {
+    glob = bashrcGlobs
     batch = false
     check = "shellcheck --external-sources {{ files }}"
   }


### PR DESCRIPTION
## Summary
- replace the manually maintained shell script glob list with hk shell type detection
- keep `.bashrc` covered by dedicated shfmt and shellcheck steps because hk narrows `glob` + `types` instead of merging them

## Verification
- `MISE_AUTO_INSTALL=0 mise exec -- hk check --all --plan --json --step shfmt --step shfmt:bashrc`
- `MISE_AUTO_INSTALL=0 mise exec -- hk check --all --plan --json --step shellcheck --step shellcheck:bashrc`
- `MISE_AUTO_INSTALL=0 mise exec -- hk check --all --check --no-progress --step shfmt --step shfmt:bashrc`
- `MISE_AUTO_INSTALL=0 mise exec -- hk check --all --check --no-progress --step shellcheck --step shellcheck:bashrc`