### PR TITLE
chore(hk): trim redundant batch settings

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -20,7 +20,8 @@ local const lintSteps = new Mapping<String, Step> {
     fix = "oxfmt {{ files }}"
   }
   ["actionlint"] = (Builtins.actionlint) {
-    // Builtins.actionlint batches by file; one invocation keeps local output concise.
+    // Builtins.actionlint's batch=true splits workflow files into parallel chunks.
+    // Keep one actionlint invocation with all files for concise local output.
     batch = false
     check = "actionlint -color {{ files }}"
     env {

--- a/hk.pkl
+++ b/hk.pkl
@@ -20,6 +20,7 @@ local const lintSteps = new Mapping<String, Step> {
     fix = "oxfmt {{ files }}"
   }
   ["actionlint"] = (Builtins.actionlint) {
+    // Builtins.actionlint batches by file; one invocation keeps local output concise.
     batch = false
     check = "actionlint -color {{ files }}"
     env {
@@ -56,7 +57,6 @@ local const lintSteps = new Mapping<String, Step> {
   }
   ["shfmt"] {
     types = shellTypes
-    batch = false
     check_diff = shfmtCheck
     fix = shfmtFix
   }
@@ -64,18 +64,15 @@ local const lintSteps = new Mapping<String, Step> {
   // separate steps because it has no shell extension or shebang.
   ["shfmt:bashrc"] {
     glob = bashrcGlobs
-    batch = false
     check_diff = shfmtCheck
     fix = shfmtFix
   }
   ["shellcheck"] {
     types = shellTypes
-    batch = false
     check = shellcheckCheck
   }
   ["shellcheck:bashrc"] {
     glob = bashrcGlobs
-    batch = false
     check = shellcheckCheck
   }
   ["pwsh"] {


### PR DESCRIPTION
## Summary
- keep `actionlint` non-batched and document why it overrides the built-in default
- remove redundant `batch = false` settings from custom shell steps, including the `.bashrc` variants now present on `main`

## Batch Behavior
In hk, `batch = false` is the default. It creates one job for the step and passes all matched files to one command invocation. hk still has separate ARG_MAX auto-batching at execution time, so an oversized rendered command can be split even when `batch = false`.

`batch = true` intentionally splits the matched file list into parallel chunks based on hk job count. That is useful for slow, single-threaded tools where each chunk is independent and parallel output is acceptable. It is less useful when the file set is small, when one tool invocation gives clearer output, or when the command needs whole-project context.

## Current Choice
- `actionlint`: keep `batch = false`; the workflow file set is small and one `actionlint` invocation keeps local output concise. The built-in default uses `batch = true`, which splits these files into parallel chunks.
- `shfmt` / `shellcheck`: rely on hk default `batch = false`; this preserves existing behavior while removing redundant config. The repo currently has a small shell file set, and the `.bashrc` steps each match one file.

## Verification
- `MISE_AUTO_INSTALL=0 mise exec -- hk check --all --plan --json --step actionlint --step shfmt --step shfmt:bashrc --step shellcheck --step shellcheck:bashrc`
- effective config: `actionlint=false`, `shfmt=false`, `shfmt:bashrc=false`, `shellcheck=false`, `shellcheck:bashrc=false`
- `MISE_AUTO_INSTALL=0 mise exec -- hk check --all --check --no-progress --step actionlint --step shfmt --step shfmt:bashrc --step shellcheck --step shellcheck:bashrc`