### PR TITLE
fix(hk): run pwsh checks for psd1 files

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -70,8 +70,8 @@ local const lintSteps = new Mapping<String, Step> {
     check = "shellcheck --external-sources {{ files }}"
   }
   ["pwsh"] {
-    glob = List("win/**/*.ps1", "win/**/*.psd1")
-    check = "pwsh -Command 'Invoke-ScriptAnalyzer -Path win -Recurse -EnableExit -Settings win/PSScriptAnalyzerSettings.psd1'"
+    glob = List("win/**/*.ps1", "win/**/*.psd1", "win/**/*.psm1")
+    check = "pwsh -NoProfile -Command 'Invoke-ScriptAnalyzer -Path win -Recurse -EnableExit -Settings win/PSScriptAnalyzerSettings.psd1'"
   }
   ["yamlfmt"] = (Builtins.yamlfmt) {
     types = List("yaml")

--- a/hk.pkl
+++ b/hk.pkl
@@ -70,7 +70,7 @@ local const lintSteps = new Mapping<String, Step> {
     check = "shellcheck --external-sources {{ files }}"
   }
   ["pwsh"] {
-    glob = List("win/**/*.ps1")
+    glob = List("win/**/*.ps1", "win/**/*.psd1")
     check = "pwsh -Command 'Invoke-ScriptAnalyzer -Path win -Recurse -EnableExit -Settings win/PSScriptAnalyzerSettings.psd1'"
   }
   ["yamlfmt"] = (Builtins.yamlfmt) {


### PR DESCRIPTION
## Summary
- include `win/**/*.psd1` in the hk pwsh step trigger list
- ensure changes to `win/PSScriptAnalyzerSettings.psd1` run the recursive `Invoke-ScriptAnalyzer` check

## Verification
- `MISE_AUTO_INSTALL=0 mise exec -- hk check --all --plan --json --step pwsh`
- `MISE_AUTO_INSTALL=0 mise exec -- hk check --all --check --no-progress --step pwsh`