### PR TITLE
docs(hk): note json type coverage

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -99,6 +99,7 @@ local const lintSteps = new Mapping<String, Step> {
     exclusive = true
   }
   ["jsonschema"] {
+    // hk maps .jsonc and .json5 to the json type.
     types = List("json")
     check = "jschema-validator"
   }


### PR DESCRIPTION
## Summary
- document that hk maps `.jsonc` and `.json5` files to the `json` type
- keep the existing `types = List("json")` config because it already covers JSON, JSONC, and JSON5

## Verification
- hk v1.45.0 source maps `.jsonc` and `.json5` to the `json` type: https://github.com/jdx/hk/blob/v1.45.0/src/file_type.rs#L292-L301
- `MISE_AUTO_INSTALL=0 mise exec -- hk check --plan --json --step jsonschema .github/renovate.json5 .markdownlint-cli2.jsonc worker/wrangler.jsonc`
- `MISE_AUTO_INSTALL=0 mise exec -- hk check --no-progress --step jsonschema .github/renovate.json5 .markdownlint-cli2.jsonc worker/wrangler.jsonc`