### PR TITLE
feat(wsl): update cargo wrapper limits and logging

### DIFF
--- a/wsl/home/.local/bin/cargo
+++ b/wsl/home/.local/bin/cargo
@@ -1,17 +1,69 @@
 #!/usr/bin/env bash
-# Caps parallel invocations of selected cargo subcommands to 3 processes
+# Caps parallel invocations of selected cargo subcommands to 4 processes
 # via GNU sem (separate from per-invocation -j).
 set -euo pipefail
 
 REAL_CARGO="${REAL_CARGO:-${HOME}/.cargo/bin/cargo}"
+LOG_FILE="${CARGO_WRAPPER_LOG:-${HOME}/.cache/cargo-wrapper/cargo.log}"
 readonly SEM_ID="cargo-wrapper-${UID}"
+
+shell_join() {
+	local joined
+
+	(($# == 0)) && return 0
+	printf -v joined '%q ' "$@"
+	printf '%s' "${joined% }"
+}
+
+log_run() {
+	local start_time=$1
+	local start_ns=$2
+	local status=$3
+	shift 3
+
+	local end_time end_ns duration_ms command sccache
+	end_time=$(date --iso-8601=seconds)
+	end_ns=$(date +%s%N)
+	duration_ms=$(((end_ns - start_ns) / 1000000))
+	command=$(shell_join "$@")
+	sccache=false
+	if [[ ${RUSTC_WRAPPER:-} == sccache || ${RUSTC_WRAPPER:-} == */sccache ]]; then
+		sccache=true
+	fi
+
+	mkdir -p -- "$(dirname -- "${LOG_FILE}")"
+	printf 'start=%q end=%q duration_ms=%q status=%q sccache=%q cwd=%q command=%q\n' \
+		"${start_time}" "${end_time}" "${duration_ms}" "${status}" "${sccache}" "${PWD}" "${command}" \
+		>>"${LOG_FILE}"
+}
+
+run_logged() {
+	local start_time start_ns status log_status
+	start_time=$(date --iso-8601=seconds)
+	start_ns=$(date +%s%N)
+
+	set +e
+	"$@"
+	status=$?
+	set -e
+
+	set +e
+	log_run "${start_time}" "${start_ns}" "${status}" "$@"
+	log_status=$?
+	set -e
+	if ((log_status != 0)); then
+		printf 'cargo wrapper: failed to write log: %s\n' "${LOG_FILE}" >&2
+	fi
+	return "${status}"
+}
 
 run_limited() {
 	if ! command -v sem >/dev/null 2>&1; then
 		printf '%s\n' 'cargo wrapper: sem not found (apt install parallel)' >&2
 		exit 127
 	fi
-	sem --id "${SEM_ID}" -j 3 --ungroup --fg -- "${REAL_CARGO}" "$@"
+	run_logged env CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}" \
+		sem --id "${SEM_ID}" -j 4 --ungroup --fg -- "${REAL_CARGO}" "$@"
 }
 
 if [[ ! -x ${REAL_CARGO} ]]; then
@@ -30,6 +82,6 @@ build | check | test | clippy | bench | doc | run)
 	run_limited "$@"
 	;;
 *)
-	exec "${REAL_CARGO}" "$@"
+	run_logged env CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}" "${REAL_CARGO}" "$@"
 	;;
 esac


### PR DESCRIPTION
## Summary
- cap limited cargo wrapper invocations at 4 parallel jobs
- default CARGO_BUILD_JOBS to 1 for wrapped cargo commands
- append per-invocation logs with cwd, command, start/end, duration, exit status, and sccache detection

## Tests
- bash -n wsl/home/.local/bin/cargo
- shellcheck wsl/home/.local/bin/cargo
- exercised passthrough and limited paths with a fake REAL_CARGO and temporary CARGO_WRAPPER_LOG