### PR TITLE
fix: configure cargo wrapper cache target

### DIFF
--- a/wsl/home/.local/bin/cargo
+++ b/wsl/home/.local/bin/cargo
@@ -5,6 +5,7 @@ set -euo pipefail
 
 REAL_CARGO="${REAL_CARGO:-${HOME}/.cargo/bin/cargo}"
 LOG_FILE="${CARGO_WRAPPER_LOG:-${HOME}/.cache/cargo-wrapper/cargo.log}"
+CARGO_TARGET_DIR_ROOT="${CARGO_TARGET_DIR_ROOT:-${HOME}/.cache/cargo-target}"
 readonly SEM_ID="cargo-wrapper-${UID}"
 
 shell_join() {
@@ -37,6 +38,81 @@ log_run() {
 		>>"${LOG_FILE}"
 }
 
+cargo_remote_url() {
+	local default_ref remote
+
+	default_ref=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || true)
+	if [[ -z ${default_ref} ]]; then
+		default_ref=$(git for-each-ref --format='%(refname)' 'refs/remotes/*/HEAD' 2>/dev/null | sed -n '1p')
+	fi
+	if [[ -n ${default_ref} ]]; then
+		remote=${default_ref#refs/remotes/}
+		remote=${remote%%/*}
+	elif git config --get remote.origin.url >/dev/null 2>&1; then
+		remote=origin
+	else
+		remote=$(git remote 2>/dev/null | sed -n '1p')
+	fi
+
+	[[ -n ${remote:-} ]] || return 1
+	git config --get "remote.${remote}.url" 2>/dev/null
+}
+
+canonical_remote_url() {
+	local url=$1
+
+	url=${url%/}
+	url=${url%.git}
+	case "${url}" in
+	git@*:*)
+		url=${url#git@}
+		url=${url/:/\/}
+		;;
+	ssh://git@*)
+		url=${url#ssh://git@}
+		;;
+	https://*)
+		url=${url#https://}
+		;;
+	http://*)
+		url=${url#http://}
+		;;
+	*) ;;
+	esac
+
+	printf '%s\n' "${url}"
+}
+
+cargo_target_dir() {
+	local remote_url slug hash
+
+	# shellcheck disable=SC2310
+	remote_url=$(cargo_remote_url) || return 1
+	remote_url=$(canonical_remote_url "${remote_url}")
+	slug=$(basename -- "${remote_url}")
+	slug=$(printf '%s' "${slug}" | tr -cs '[:alnum:]._-' '-')
+	slug=${slug%-}
+	hash=$(printf '%s' "${remote_url}" | sha256sum | awk '{print $1}')
+
+	printf '%s/%s-%s\n' "${CARGO_TARGET_DIR_ROOT}" "${slug:-repo}" "${hash:0:16}"
+}
+
+build_cargo_env_args() {
+	local -n out=$1
+
+	out=(
+		"CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-1}"
+		"CARGO_INCREMENTAL=0"
+	)
+
+	if [[ -z ${CARGO_TARGET_DIR:-} ]]; then
+		local target_dir
+		# shellcheck disable=SC2310
+		target_dir=$(cargo_target_dir) || return 0
+		out+=("CARGO_TARGET_DIR=${target_dir}")
+	fi
+}
+
 run_logged() {
 	local start_time start_ns status log_status
 	start_time=$(date --iso-8601=seconds)
@@ -58,11 +134,14 @@ run_logged() {
 }
 
 run_limited() {
+	local -a env_args
+
 	if ! command -v sem >/dev/null 2>&1; then
 		printf '%s\n' 'cargo wrapper: sem not found (apt install parallel)' >&2
 		exit 127
 	fi
-	run_logged env CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}" \
+	build_cargo_env_args env_args
+	run_logged env "${env_args[@]}" \
 		sem --id "${SEM_ID}" -j 4 --ungroup --fg -- "${REAL_CARGO}" "$@"
 }
 
@@ -82,6 +161,8 @@ build | check | test | clippy | bench | doc | run)
 	run_limited "$@"
 	;;
 *)
-	run_logged env CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}" "${REAL_CARGO}" "$@"
+	env_args=()
+	build_cargo_env_args env_args
+	run_logged env "${env_args[@]}" "${REAL_CARGO}" "$@"
 	;;
 esac


### PR DESCRIPTION
## Summary
- set CARGO_INCREMENTAL=0 for cargo wrapper invocations
- default CARGO_TARGET_DIR to a stable ~/.cache/cargo-target path derived from the default-branch remote, not the current branch upstream
- preserve explicitly provided CARGO_TARGET_DIR values
- leave repo-local target/ paths untouched

## Verification
- shellcheck wsl/home/.local/bin/cargo
- smoke check: feature branch tracks upstream while origin/HEAD selects origin cache key
- smoke check: upstream/HEAD fallback selects upstream cache key
- temp-repo wrapper smoke check for env values and target/ preservation
- CARGO_TARGET_DIR=/tmp/custom-target wrapper smoke check
- LINT=1 mise run check