### PR TITLE
fix: add Gemini CLI aube args

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -11,7 +11,7 @@ _.path = ["~/.local/bin"]
 # language tools
 node = "latest"
 bun = "latest"
-aube = "1.9.0" # 1.9.1+ missing GitHub attestations on linux-x64 (mise lock fails)
+aube = "1.9.0"  # 1.9.1+ missing GitHub attestations on linux-x64 (mise lock fails)
 npm = "latest"
 # Don't use the vfox plugin; it doesn't support lockfiles
 "aqua:yarn" = "latest"
@@ -65,7 +65,7 @@ glow = "latest"
 codex = "latest"
 "npm:@ccusage/codex" = "latest"
 claude = "latest"
-gemini-cli = "latest"
+gemini-cli = { version = "latest", aube_args = "--allow-build=@github/keytar --allow-build=node-pty" }
 copilot = "latest"
 
 # linter/formatter tools
@@ -92,7 +92,7 @@ numbat = "latest"
 typst = "latest"
 
 # mise development
-aqua = "2.58.0" # 2.58.1+ missing GitHub attestations on linux-x64 (mise lock fails)
+aqua = "2.58.0"    # 2.58.1+ missing GitHub attestations on linux-x64 (mise lock fails)
 pipx = "latest"
 sccache = "latest"
 

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -11,7 +11,7 @@ _.path = ["~/.local/bin"]
 # language tools
 node = "latest"
 bun = "latest"
-aube = "1.9.0"  # 1.9.1+ missing GitHub attestations on linux-x64 (mise lock fails)
+aube = "1.9.0" # 1.9.1+ missing GitHub attestations on linux-x64 (mise lock fails)
 npm = "latest"
 # Don't use the vfox plugin; it doesn't support lockfiles
 "aqua:yarn" = "latest"
@@ -92,7 +92,7 @@ numbat = "latest"
 typst = "latest"
 
 # mise development
-aqua = "2.58.0"    # 2.58.1+ missing GitHub attestations on linux-x64 (mise lock fails)
+aqua = "2.58.0" # 2.58.1+ missing GitHub attestations on linux-x64 (mise lock fails)
 pipx = "latest"
 sccache = "latest"
 

--- a/wsl/home/.config/mise/mise.lock
+++ b/wsl/home/.config/mise/mise.lock
@@ -367,6 +367,13 @@ url = "https://github.com/junegunn/fzf/releases/download/v0.72.0/fzf-0.72.0-linu
 version = "0.42.0"
 backend = "npm:@google/gemini-cli"
 
+[[tools.gemini-cli]]
+version = "0.42.0"
+backend = "npm:@google/gemini-cli"
+
+[tools.gemini-cli.options]
+aube_args = "--allow-build=@github/keytar --allow-build=node-pty"
+
 [[tools.ghalint]]
 version = "1.5.6"
 backend = "aqua:suzuki-shunsuke/ghalint"
@@ -927,7 +934,7 @@ version = "3.14.5"
 backend = "core:python"
 
 [tools.python."platforms.linux-x64"]
-checksum = "blake3:a1c289075e88a3a31f93ddffec2c4e7a75ea663b204d93d8969046cc4aebd55f"
+checksum = "sha256:dc10977b0db3bef1ee2275107fde6fe9c148135b556fa352e83c6baa67d17ed6"
 url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5+20260510-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 


### PR DESCRIPTION
## Summary
- Follow jdx/mise#9904 by setting Gemini CLI npm backend lifecycle approvals for aube.
- Use aube_args only, matching the global mise npm package_manager setting.

## Testing
- mise x taplo -- taplo fmt --check wsl/home/.config/mise/config.toml
- mise x taplo -- taplo check wsl/home/.config/mise/config.toml
- mise -C /tmp config -J get tools.gemini-cli
- git diff --check