### PR TITLE
fix(wsl): handle codex-tmux new session selection

### DIFF
--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -303,7 +303,9 @@ select_existing_session() {
 	) || exit 130
 
 	session_name=${selected%%$'\t'*}
-	[[ ${session_name} != "new" ]]
+	if [[ ${session_name} == "new" ]]; then
+		return 1
+	fi
 	printf '%s\n' "${session_name}"
 }
 


### PR DESCRIPTION
## Summary
- Treat the codex-tmux picker `new` row as a request to create a fresh worktree/session
- Keep existing session selections attachable by returning their tmux session name

## Checks
- `bash -n wsl/home/.config/mise/tasks/codex-tmux`
- `shellcheck wsl/home/.config/mise/tasks/codex-tmux`
- selector harness for `new` and existing-session choices
- `LINT=1 mise run check`