### PR TITLE
docs(codex): clarify PR settling follow-ups

### DIFF
--- a/wsl/home/.codex/AGENTS.md
+++ b/wsl/home/.codex/AGENTS.md
@@ -84,8 +84,9 @@ When settling a PR:
 - Apply valid review suggestions.
 - For ignored suggestions, leave a brief explanation, then resolve the thread.
 - Before treating a CI failure as unrelated, inspect the failed GitHub Actions
-  logs and check previous CI runs for other branches if any failed, so the
-  conclusion is based on evidence outside this PR.
+  logs and compare against the CI status of the base branch and recent runs for
+  other branches, if any have failed, to verify whether the failure is systemic
+  rather than caused by this PR.
 - If CI fails for reasons unrelated to the change, do not fix unrelated failures
   unless asked. Leave a PR comment explaining why the failure appears unrelated.
 - If the branch becomes conflicted with the base branch, rebase it onto the

--- a/wsl/home/.codex/AGENTS.md
+++ b/wsl/home/.codex/AGENTS.md
@@ -72,6 +72,10 @@ Only settle a PR when the user explicitly asks, for example:
 - “follow up until everything settles”
 - “wait for checks and reviews”
 
+If the user asks to settle a PR at any point in the session, keep settling that
+PR after subsequent follow-up work in the same session, such as fix requests,
+until the user explicitly overrides that instruction.
+
 When settling a PR:
 
 - Wait until all relevant CI checks are no longer pending, queued, in progress,
@@ -79,6 +83,9 @@ When settling a PR:
 - Wait until AI/code reviews have completed.
 - Apply valid review suggestions.
 - For ignored suggestions, leave a brief explanation, then resolve the thread.
+- Before treating a CI failure as unrelated, inspect the failed GitHub Actions
+  logs and check previous CI runs for other branches if any failed, so the
+  conclusion is based on evidence outside this PR.
 - If CI fails for reasons unrelated to the change, do not fix unrelated failures
   unless asked. Leave a PR comment explaining why the failure appears unrelated.
 - If the branch becomes conflicted with the base branch, rebase it onto the


### PR DESCRIPTION
## Summary
- Carry an explicit PR-settling request through follow-up work in the same session unless explicitly overridden.
- Require checking failed GitHub Actions logs and previous branch CI runs before treating a failure as unrelated.

## Testing
- Not run; documentation-only change.