### PR TITLE
feat(wsl): move codex worktrunks under home

### DIFF
--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -502,7 +502,7 @@ branch_merged_into_default() {
 	local default_ref
 
 	default_ref=$(default_checkout_ref "${repo_path}")
-	git -C "${repo_path}" merge-base --is-ancestor "${branch}" "${default_ref}" 2>/dev/null
+	git -C "${repo_path}" merge-base --is-ancestor "refs/heads/${branch}" "${default_ref}" 2>/dev/null
 }
 
 branch_pr_state() {

--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -321,14 +321,11 @@ create_worktree() {
 	local repo_path=$1
 	local worktree_id=$2
 	local checkout_ref=$3
-	local path
+	local output path
 
-	path="${repo_path}.${worktree_id}"
-	if [[ -e ${path} ]]; then
-		die "worktree path already exists: ${path}"
-	fi
-
-	git -C "${repo_path}" worktree add --detach "${path}" "${checkout_ref}" >/dev/null
+	output=$(wt -C "${repo_path}" switch --create "${worktree_id}" --base "${checkout_ref}" --no-cd --no-hooks --format json)
+	path=$(jq -r '.path // empty' <<<"${output}")
+	[[ -n ${path} ]] || die "worktrunk did not report a worktree path"
 
 	printf '%s\n' "${path}"
 }
@@ -499,6 +496,15 @@ branch_has_remote() {
 	git -C "${repo_path}" show-ref --verify --quiet "refs/remotes/origin/${branch}"
 }
 
+branch_merged_into_default() {
+	local repo_path=$1
+	local branch=$2
+	local default_ref
+
+	default_ref=$(default_checkout_ref "${repo_path}")
+	git -C "${repo_path}" merge-base --is-ancestor "${branch}" "${default_ref}" 2>/dev/null
+}
+
 branch_pr_state() {
 	local repo_name=$1
 	local branch=$2
@@ -537,6 +543,11 @@ stale_worktree_reason() {
 		;;
 	*) ;;
 	esac
+
+	if branch_merged_into_default "${repo_path}" "${branch}"; then
+		printf 'merged-default\n'
+		return 0
+	fi
 
 	if ! branch_has_remote "${repo_path}" "${branch}"; then
 		return 1

--- a/wsl/home/.config/worktrunk/config.toml
+++ b/wsl/home/.config/worktrunk/config.toml
@@ -1,0 +1,3 @@
+# Worktrunk does not currently expose the remote host in worktree-path templates,
+# so ghr-managed repositories are grouped by owner/repo below ~/.worktrunk.
+worktree-path = '~/.worktrunk/{{ owner | default("local") }}/{{ repo }}/{{ repo }}.{{ branch | sanitize }}'


### PR DESCRIPTION
## Summary
- add Worktrunk user config to place worktrees under ~/.worktrunk by owner/repo
- create codex-tmux worktrees through Worktrunk so the configured path is honored
- allow stale cleanup to remove clean local branches already contained in the default ref

## Tests
- bash -n wsl/home/.config/mise/tasks/codex-tmux
- shellcheck wsl/home/.config/mise/tasks/codex-tmux
- shfmt -d wsl/home/.config/mise/tasks/codex-tmux
- taplo format --check wsl/home/.config/worktrunk/config.toml
- wt --config wsl/home/.config/worktrunk/config.toml -C <temp-repo> switch --create codex-verify --base HEAD --no-cd --no-hooks --format json