### PR TITLE
fix(wsl): route bare ghr cd through picker

### DIFF
--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -161,12 +161,16 @@ if command -v ghr &>/dev/null; then
 		cd "${path}" || return
 	}
 	ghr() {
-		local arg
+		local arg ghr_bin="${__GHR:-}" has_cd=false
 		local -a cd_args
+
+		if [[ -z ${ghr_bin} ]]; then
+			ghr_bin=$(type -P ghr) || return
+		fi
 
 		for arg in "$@"; do
 			if [[ ${arg} == "-h" || ${arg} == "--help" ]]; then
-				"${__GHR}" "$@"
+				"${ghr_bin}" "$@"
 				return
 			fi
 		done
@@ -179,14 +183,16 @@ if command -v ghr &>/dev/null; then
 				return
 				;;
 			clone | init)
-				if (($# > 1)) && __ghr_contains "--cd" "${@:2}"; then
-					if ! "${__GHR}" "$@"; then
-						return
+				cd_args=()
+				for arg in "${@:2}"; do
+					if [[ ${arg} == "--cd" ]]; then
+						has_cd=true
+					else
+						cd_args+=("${arg}")
 					fi
-					cd_args=()
-					for arg in "${@:2}"; do
-						[[ ${arg} == "--cd" ]] || cd_args+=("${arg}")
-					done
+				done
+				if [[ ${has_cd} == true ]]; then
+					"${ghr_bin}" "$@" || return
 					__ghr_cd "${cd_args[@]}"
 					return
 				fi
@@ -195,7 +201,7 @@ if command -v ghr &>/dev/null; then
 			esac
 		fi
 
-		"${__GHR}" "$@"
+		"${ghr_bin}" "$@"
 	}
 	ghr_completion="$(ghr shell bash --completion)"
 	eval "${ghr_completion}"

--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -160,6 +160,43 @@ if command -v ghr &>/dev/null; then
 		[[ -n ${path} ]] || return 1
 		cd "${path}" || return
 	}
+	ghr() {
+		local arg
+		local -a cd_args
+
+		for arg in "$@"; do
+			if [[ ${arg} == "-h" || ${arg} == "--help" ]]; then
+				"${__GHR}" "$@"
+				return
+			fi
+		done
+
+		if (($# > 0)); then
+			case "$1" in
+			cd)
+				shift
+				__ghr_cd "$@"
+				return
+				;;
+			clone | init)
+				if (($# > 1)) && __ghr_contains "--cd" "${@:2}"; then
+					if ! "${__GHR}" "$@"; then
+						return
+					fi
+					cd_args=()
+					for arg in "${@:2}"; do
+						[[ ${arg} == "--cd" ]] || cd_args+=("${arg}")
+					done
+					__ghr_cd "${cd_args[@]}"
+					return
+				fi
+				;;
+			*) ;;
+			esac
+		fi
+
+		"${__GHR}" "$@"
+	}
 	ghr_completion="$(ghr shell bash --completion)"
 	eval "${ghr_completion}"
 fi


### PR DESCRIPTION
## Summary
- override the generated ghr wrapper after loading the shell extension
- route bare `ghr cd` through the fzf-aware `__ghr_cd` helper
- preserve explicit `ghr cd <repo>`, help handling, and `clone/init --cd` behavior

## Tests
- bash -n wsl/home/.bashrc
- shellcheck wsl/home/.bashrc
- shfmt -d wsl/home/.bashrc
- sourced-shell test for bare `ghr cd` with a stubbed `fzf` selecting `github.com:risu729/dotfiles`
- sourced-shell test for explicit `ghr cd github.com:risu729/dotfiles`