### PR TITLE
feat(codex): sync before creating tmux worktrees

### DIFF
--- a/wsl/home/.codex/AGENTS.md
+++ b/wsl/home/.codex/AGENTS.md
@@ -5,6 +5,9 @@
 - Prefer `gh pr checkout` when checking out an existing pull request.
 - Use `ghr clone` when cloning repositories temporarily.
   - Use `ghr list` to inspect existing temporary clones.
+- Before rebasing, resolving conflicts, or otherwise relying on remote branch
+  state, run `git fetch --all --prune` or an equivalent sync command so every
+  configured remote, including `origin` and `upstream`, is current.
 - Do not force-push unless it is clearly necessary.
   - Prefer `--force-with-lease` over `--force`.
   - Do not force-push just to clean up history unless explicitly asked.

--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -215,6 +215,12 @@ default_checkout_ref() {
 	fi
 }
 
+sync_repo() {
+	local repo_path=$1
+
+	git -C "${repo_path}" sync
+}
+
 resolve_explicit_repo() {
 	local input=$1
 	local repo_path repo_name
@@ -756,6 +762,7 @@ main() {
 		attach_session "${session_name}"
 	fi
 
+	sync_repo "${repo_path}"
 	worktree_id=$(new_worktree_id)
 	checkout_ref=$(default_checkout_ref "${repo_path}")
 	worktree_path=$(create_worktree "${repo_path}" "${worktree_id}" "${checkout_ref}")

--- a/wsl/home/.gitconfig
+++ b/wsl/home/.gitconfig
@@ -29,6 +29,6 @@
 
 [alias]
 	sm = "!branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null); branch=${branch#origin/}; if [ -z \"$branch\" ]; then branch=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); fi; [ -n \"$branch\" ] && git switch \"$branch\""
-	sync = !curr=$(git rev-parse --abbrev-ref HEAD) && git fetch --all && git submodule update --init --recursive && git pull --ff-only upstream \"$curr\" && git push origin \"$curr\"
+	sync = "!curr=$(git rev-parse --abbrev-ref HEAD) && git fetch --all && git submodule update --init --recursive && if git remote get-url upstream >/dev/null 2>&1; then git pull --ff-only upstream \"$curr\" && git push origin \"$curr\"; else git pull --ff-only; fi"
 [gpg]
 	program = gpg


### PR DESCRIPTION
## Summary
- add global agent guidance to refresh all configured remotes before rebasing or relying on remote branch state
- run `git sync` before codex-tmux creates a new Worktrunk worktree

## Tests
- `bash -n wsl/home/.config/mise/tasks/codex-tmux`
- `mise x --no-deps shellcheck -- shellcheck wsl/home/.config/mise/tasks/codex-tmux`
- `mise x --no-deps shfmt -- shfmt -d wsl/home/.config/mise/tasks/codex-tmux`