### PR TITLE
fix(wsl): install agent skills as files

### DIFF
--- a/wsl/home/.agents/skills/pr-tree/scripts/pr-tree.py
+++ b/wsl/home/.agents/skills/pr-tree/scripts/pr-tree.py
@@ -10,7 +10,8 @@ DEPENDENCY_RE = re.compile(
     r"(depends?\s+on|requires?|stacked\s+on|based\s+on|blocked\s+on)",
     re.IGNORECASE,
 )
-URL_RE = re.compile(r"https://github\.com/([^/\s]+)/([^/\s]+)/pull/(\d+)")
+GITHUB_URL_PREFIX = "https://github.com/"
+URL_RE = re.compile(re.escape(GITHUB_URL_PREFIX) + r"([^/\s]+)/([^/\s]+)/pull/(\d+)")
 OWNER_REPO_RE = re.compile(r"([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(\d+)")
 LOCAL_REF_RE = re.compile(r"(?<![A-Za-z0-9_/.-])#(\d+)")
 

--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -223,9 +223,19 @@ create_home_symlinks() {
 		local target_path="${HOME}/${target_name}"
 
 		mkdir --parents "$(dirname "${target_path}")"
-		ln --symbolic --no-dereference --force "${full_path}" "${target_path}"
-		# shellcheck disable=SC2088 # intentionally print ~ instead of $HOME
-		log_info "Installed symlink: ~/${target_name}"
+		if [[ ${target_name} == .agents/skills/* ]]; then
+			# Codex skips symlinked skill files during skill discovery.
+			local file_mode
+			file_mode=$(stat --format=%a "${full_path}")
+			rm --force "${target_path}"
+			install --mode="${file_mode}" "${full_path}" "${target_path}"
+			# shellcheck disable=SC2088 # intentionally print ~ instead of $HOME
+			log_info "Installed file: ~/${target_name}"
+		else
+			ln --symbolic --no-dereference --force "${full_path}" "${target_path}"
+			# shellcheck disable=SC2088 # intentionally print ~ instead of $HOME
+			log_info "Installed symlink: ~/${target_name}"
+		fi
 	done
 }
 

--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -225,10 +225,7 @@ create_home_symlinks() {
 		mkdir --parents "$(dirname "${target_path}")"
 		if [[ ${target_name} == .agents/skills/* ]]; then
 			# Codex skips symlinked skill files during skill discovery.
-			local file_mode
-			file_mode=$(stat --format=%a "${full_path}")
-			rm --force "${target_path}"
-			install --mode="${file_mode}" "${full_path}" "${target_path}"
+			cp --preserve=mode --remove-destination "${full_path}" "${target_path}"
 			# shellcheck disable=SC2088 # intentionally print ~ instead of $HOME
 			log_info "Installed file: ~/${target_name}"
 		else


### PR DESCRIPTION
## Summary
- install files under `~/.agents/skills/` as regular files instead of symlinks
- keep normal home dotfiles installed as symlinks
- preserve source file modes so bundled skill scripts stay executable
- avoid a broken URL-like regex literal in the PR tree script so link lint passes

## Why
Codex omits symlinked `SKILL.md` files from the model-visible skills list, so the dotfiles-managed `pr-tree` skill was present on disk but not discoverable.

## Verification
- `bash -n wsl/install.sh`
- `git diff --check`
- `shellcheck --external-sources wsl/install.sh`
- `shfmt --diff --simplify wsl/install.sh`
- `python3 -m py_compile wsl/home/.agents/skills/pr-tree/scripts/pr-tree.py`
- `lychee --no-progress --verbose wsl/home/.agents/skills/pr-tree/scripts/pr-tree.py`
- simulated `create_home_symlinks` with a temp home and confirmed `.agents/skills/pr-tree/*` were regular files while `.bashrc` remained a symlink