### PR TITLE
fix(wsl): avoid generated ghr cd wrapper

### DIFF
--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -131,7 +131,7 @@ fi
 # Install ghr shell extension and enable completion
 if command -v ghr &>/dev/null; then
 	# The generated shell wrapper requires an argument after `ghr cd`.
-	__GHR=$(type -P ghr) || return
+__GHR=$(type -P ghr) || :
 	__ghr_cd() {
 		local ghr_bin="${__GHR:-}" path selected
 

--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -130,8 +130,8 @@ fi
 
 # Install ghr shell extension and enable completion
 if command -v ghr &>/dev/null; then
-	ghr_extension="$(ghr shell bash)"
-	eval "${ghr_extension}"
+	# The generated shell wrapper requires an argument after `ghr cd`.
+	__GHR=$(type -P ghr) || return
 	__ghr_cd() {
 		local ghr_bin="${__GHR:-}" path selected
 
@@ -203,7 +203,7 @@ if command -v ghr &>/dev/null; then
 
 		"${ghr_bin}" "$@"
 	}
-	ghr_completion="$(ghr shell bash --completion)"
+	ghr_completion="$("${__GHR}" shell bash --completion)"
 	eval "${ghr_completion}"
 fi
 

--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -131,7 +131,7 @@ fi
 # Install ghr shell extension and enable completion
 if command -v ghr &>/dev/null; then
 	# The generated shell wrapper requires an argument after `ghr cd`.
-__GHR=$(type -P ghr) || :
+	__GHR=$(type -P ghr) || :
 	__ghr_cd() {
 		local ghr_bin="${__GHR:-}" path selected
 


### PR DESCRIPTION
## Summary
- stop evaluating the generated `ghr shell bash` wrapper in `.bashrc`
- resolve the real `ghr` binary with `type -P` and keep the local wrapper responsible for bare `ghr cd`
- generate completion from the resolved binary so completion setup does not depend on the wrapper

## Root cause
`ghr shell bash` emits a `ghr()` wrapper that only handles `ghr cd` when more than one argument is present. Bare `ghr cd` therefore falls through to the `ghr` binary, which reports the default missing `<REPO>` behavior instead of opening `fzf`.

## Tests
- `shfmt --diff --simplify wsl/home/.bashrc`
- `shellcheck --external-sources wsl/home/.bashrc`
- `bash -ic 'source /home/risu/.worktrunk/risu729/dotfiles/dotfiles.codex-20260519-201843-15cb7a/wsl/home/.bashrc; start=$PWD; FZF_DEFAULT_OPTS="--filter=cloudflare/wrangler-action" ghr cd; printf "start=%s\\nnow=%s\\n" "$start" "$PWD"'`
