### PR TITLE
fix(mise): skip installed PSScriptAnalyzer

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -13,7 +13,7 @@ shell = "pwsh -Command"
 run = """
 $RequiredVersion = '{{ vars.PS_SCRIPT_ANALYZER_VERSION }}'
 
-if (Get-Module -ListAvailable -Name PSScriptAnalyzer | Where-Object { $_.Version -eq [version]$RequiredVersion } | Select-Object -First 1) {
+if (Get-Module -ListAvailable -FullyQualifiedName @{ ModuleName = 'PSScriptAnalyzer'; RequiredVersion = $RequiredVersion }) {
   exit 0
 }
 

--- a/tasks.toml
+++ b/tasks.toml
@@ -10,4 +10,12 @@ description = "Run hk linters and formatters."
 shell = "pwsh -Command"
 # Force is required to bypass untrusted repository confirmation
 # ref: https://github.com/PowerShell/PowerShellGetv2/issues/461
-run = "Install-Module -Name PSScriptAnalyzer -RequiredVersion {{ vars.PS_SCRIPT_ANALYZER_VERSION }} -Force"
+run = """
+$RequiredVersion = '{{ vars.PS_SCRIPT_ANALYZER_VERSION }}'
+
+if (Get-Module -ListAvailable -Name PSScriptAnalyzer | Where-Object { $_.Version -eq [version]$RequiredVersion } | Select-Object -First 1) {
+  exit 0
+}
+
+Install-Module -Name PSScriptAnalyzer -RequiredVersion $RequiredVersion -Force
+"""


### PR DESCRIPTION
## Summary
- skip PSScriptAnalyzer installation when the configured version is already installed
- keep Install-Module as the fallback for missing versions

## Tests
- mise run --no-deps install:ps-script-analyzer
- mise run check