### PR TITLE
chore(deps): replace @ccusage/codex with ccusage

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -63,7 +63,7 @@ glow = "latest"
 
 # ai agents
 codex = "latest"
-"npm:@ccusage/codex" = "latest"
+"npm:ccusage" = "latest"
 claude = "latest"
 gemini-cli = { version = "latest", aube_args = "--allow-build=@github/keytar --allow-build=node-pty" }
 copilot = "latest"
@@ -118,4 +118,4 @@ c = "mise run codex-tmux"
 l = "eza --all --long --git"
 k = "kubecolor"
 aptup = "sudo apt update && sudo apt upgrade -y"
-cux = "ccusage-codex"
+cux = "ccusage codex"

--- a/wsl/home/.config/mise/mise.lock
+++ b/wsl/home/.config/mise/mise.lock
@@ -826,9 +826,9 @@ url = "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz"
 [tools.npm."platforms.linux-x64-musl-baseline"]
 url = "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz"
 
-[[tools."npm:@ccusage/codex"]]
-version = "19.0.0"
-backend = "npm:@ccusage/codex"
+[[tools."npm:ccusage"]]
+version = "20.0.1"
+backend = "npm:ccusage"
 
 [[tools."npm:resend-cli"]]
 version = "2.2.1"


### PR DESCRIPTION
## Summary
- replace the deprecated npm:@ccusage/codex mise tool with npm:ccusage
- lock ccusage to 20.0.1 in the global mise lockfile
- update the cux alias to expand to ccusage codex

## Tests
- tombi lint wsl/home/.config/mise/config.toml wsl/home/.config/mise/mise.lock
- tombi format --check --diff wsl/home/.config/mise/config.toml wsl/home/.config/mise/mise.lock
- npx --yes ccusage@20.0.1 codex --help