### PR TITLE
ci(lint): run lychee only in scheduled lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,6 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Cache lychee
+        if: ${{ github.event_name == 'schedule' }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .lycheecache
@@ -54,6 +55,7 @@ jobs:
         run: mise run check
         env:
           LINT: true
+          SCHEDULED_LINT: ${{ github.event_name == 'schedule' }}
           GITHUB_TOKEN: ${{ github.token }}
 
   actions-timeline:

--- a/hk.pkl
+++ b/hk.pkl
@@ -96,6 +96,7 @@ local const lintSteps = new Mapping<String, Step> {
   }
   ["lychee"] = (Builtins.lychee) {
     check = "lychee --no-progress --verbose {{ files }}"
+    profiles = List("scheduled")
   }
   ["typos"] = Builtins.typos
   ["ignore-sync"] {

--- a/tasks.toml
+++ b/tasks.toml
@@ -2,7 +2,7 @@
 #:schema https://mise.jdx.dev/schema/mise-task.json
 
 [check]
-run = "hk {% if env.CI is defined %}--profile ci {% endif %}{% if env.LINT is defined %}check{% else %}fix{% endif %} --all --no-progress --no-fail-fast"
+run = "hk {% if env.CI is defined %}--profile ci {% endif %}{% if env.SCHEDULED_LINT is defined and env.SCHEDULED_LINT == 'true' %}--profile scheduled {% endif %}{% if env.LINT is defined %}check{% else %}fix{% endif %} --all --no-progress --no-fail-fast"
 env.GH_TOKEN = "{% if env.GITHUB_TOKEN is defined %}{{ env.GITHUB_TOKEN }}{% endif %}"
 description = "Run hk linters and formatters."
 


### PR DESCRIPTION
## Summary
- add a scheduled HK profile gate for lychee
- pass the scheduled profile only from the scheduled lint workflow
- cache lychee only for scheduled lint runs

## Testing
- mise fmt --check && mise task validate && mise x hk@1.45.0 -- hk validate
- CI=true LINT=true SCHEDULED_LINT=false mise run --no-deps check
- mise x hk@1.45.0 -- hk --profile ci check --all --no-progress --plan
- mise x hk@1.45.0 -- hk --profile ci --profile scheduled check --all --no-progress --plan