### PR TITLE
feat(wsl): add explicit zoxide z alias

### DIFF
--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -97,7 +97,7 @@ fi
 
 # Activate zoxide
 if command -v zoxide &>/dev/null; then
-	zoxide_init="$(zoxide init bash)"
+	zoxide_init="$(zoxide init bash --cmd z)"
 	eval "${zoxide_init}"
 	unset zoxide_init
 fi


### PR DESCRIPTION
## Summary
- Make zoxide bash initialization explicitly request the z shell command via --cmd z

## Testing
- mise x shfmt -- shfmt --diff --simplify wsl/home/.bashrc
- mise x shellcheck -- shellcheck --external-sources wsl/home/.bashrc
- git diff --check
- bash --rcfile wsl/home/.bashrc -ic 'type z'

Closes #3368