### PR TITLE
fix(wsl): disable atuin up-arrow binding

### DIFF
--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -389,7 +389,7 @@ fi
 
 # Activate atuin
 if command -v atuin &>/dev/null; then
-	atuin_init="$(atuin init bash)"
+	atuin_init="$(atuin init bash --disable-up-arrow)"
 	eval "${atuin_init}"
 	unset atuin_init
 fi


### PR DESCRIPTION
## Summary
- pass `--disable-up-arrow` to `atuin init bash` so Atuin does not override the shell Up-arrow behavior

## Tests
- `LINT=1 mise run check`