### PR TITLE
fix(wsl): lock gemini cli mise backend

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -66,7 +66,7 @@ glow = "latest"
 codex = "latest"
 "npm:ccusage" = "latest"
 claude = "latest"
-gemini-cli = { version = "latest", aube_args = "--allow-build=@github/keytar --allow-build=node-pty" }
+"npm:@google/gemini-cli" = { version = "0.43.0", aube_args = "--allow-build=@github/keytar --allow-build=node-pty" }
 copilot = "latest"
 
 # linter/formatter tools

--- a/wsl/home/.config/mise/mise.lock
+++ b/wsl/home/.config/mise/mise.lock
@@ -384,13 +384,6 @@ url = "https://github.com/junegunn/fzf/releases/download/v0.73.1/fzf-0.73.1-linu
 checksum = "sha256:f3252c2c366bc1700d3c85781ec8c9695998927ac127870eb049ceea2d540f8a"
 url = "https://github.com/junegunn/fzf/releases/download/v0.73.1/fzf-0.73.1-linux_amd64.tar.gz"
 
-[[tools.gemini-cli]]
-version = "0.43.0"
-backend = "npm:@google/gemini-cli"
-
-[tools.gemini-cli.options]
-aube_args = "--allow-build=@github/keytar --allow-build=node-pty"
-
 [[tools.ghalint]]
 version = "1.5.6"
 backend = "aqua:suzuki-shunsuke/ghalint"
@@ -835,6 +828,13 @@ url = "https://registry.npmjs.org/npm/-/npm-11.15.0.tgz"
 
 [tools.npm."platforms.linux-x64-musl-baseline"]
 url = "https://registry.npmjs.org/npm/-/npm-11.15.0.tgz"
+
+[[tools."npm:@google/gemini-cli"]]
+version = "0.43.0"
+backend = "npm:@google/gemini-cli"
+
+[tools."npm:@google/gemini-cli".options]
+aube_args = "--allow-build=@github/keytar --allow-build=node-pty"
 
 [[tools."npm:ccusage"]]
 version = "20.0.5"


### PR DESCRIPTION
## Summary
- use the explicit `npm:@google/gemini-cli` mise backend in the WSL global config
- keep the WSL mise lockfile aligned with that backend so `mise install --locked` can resolve Gemini deterministically

## Verification
- `mise install --locked --dry-run -C wsl/home/.config/mise`
- `mise run check`
