### PR TITLE
fix(worker): pin installer fetches to commit SHA in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
       - name: Run tests
         run: mise run worker:test
         env:
-          CURRENT_BRANCH: ${{ case(github.event_name == 'pull_request', github.head_ref, github.ref_name) }}
           GITHUB_TOKEN: ${{ github.token }}
 
   ci-check:

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -4,11 +4,6 @@ import process from "node:process";
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
-const currentBranch: string =
-	process.env["CURRENT_BRANCH"] ?? execSync("git branch --show-current").toString().trim();
-if (!currentBranch) {
-	throw new Error("Could not determine current branch from git.");
-}
 const latestCommitHash: string = execSync("git rev-parse HEAD").toString().trim();
 if (!latestCommitHash) {
 	throw new Error("Could not determine latest commit hash from git.");
@@ -25,8 +20,8 @@ export default defineConfig({
 	],
 	test: {
 		env: {
-			// Use current branch name as default branch for testing
-			DEFAULT_BRANCH: currentBranch,
+			// Pin fetches to the checked-out commit so raw.githubusercontent.com stays consistent.
+			DEFAULT_BRANCH: latestCommitHash,
 
 			// Define in vite.config.ts does not work in vitest, so define here
 			GITHUB_TOKEN: process.env["GITHUB_TOKEN"],


### PR DESCRIPTION
## Summary
- Set vitest `DEFAULT_BRANCH` to `git rev-parse HEAD` instead of the PR branch name
- Remove unused `CURRENT_BRANCH` from the worker CI job

This pins `raw.githubusercontent.com` fetches to an immutable commit SHA, avoiding CDN races when `wsl/install.sh` or `win/install.ps1` change on a PR branch.

## Test plan
- [x] `CI=true mise run worker:test` passes locally
- [ ] Cloudflare Workers Tests CI job passes on this PR


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Pin worker tests to the current commit SHA instead of the branch name and remove now-unnecessary CI configuration.

Bug Fixes:
- Ensure worker tests fetch installer scripts from an immutable commit SHA to avoid races when branch content changes.

CI:
- Remove the CURRENT_BRANCH environment variable from the worker CI job now that tests derive the commit hash directly from git.