### PR TITLE
perf(ci): cache Ubuntu WSL image download in test-linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       contents: read # for checkout
     env:
       COMPOSE_PROJECT_NAME: dotfiles-ci-${{ github.run_id }}-${{ github.run_attempt }}
+      # Keep WSL image target stable because newest LTS metadata can
+      # appear before cdimages publishes the corresponding wsl artifact.
+      WSL_IMAGE_URL: https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/current/noble-wsl-amd64.wsl
 
     steps:
       - name: Checkout
@@ -82,12 +85,30 @@ jobs:
           fi
           echo "MISE_VERSION=${mise_version}" >> "${GITHUB_ENV}"
 
+      - name: Resolve Ubuntu WSL image version
+        id: wsl-image
+        run: |
+          etag=$(
+            curl --fail-with-body --silent --head --location "${WSL_IMAGE_URL}" |
+              awk -F': ' 'tolower($1) == "etag" { gsub(/\r/, "", $2); print $2; exit }'
+          )
+          etag="${etag//\"/}"
+          if [[ -z ${etag} ]]; then
+            echo "Failed to read WSL image ETag." >&2
+            exit 1
+          fi
+          echo "etag=${etag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Cache Ubuntu WSL image
+        id: wsl-cache
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: wsl-amd64.wsl
+          key: ubuntu-wsl-noble-${{ steps.wsl-image.outputs.etag }}
+
       - name: Download Ubuntu WSL image
-        run: curl --fail-with-body --location --output wsl-amd64.wsl "${IMAGE_URL}"
-        env:
-          # Keep WSL image target stable because newest LTS metadata can
-          # appear before cdimages publishes the corresponding wsl artifact.
-          IMAGE_URL: https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/current/noble-wsl-amd64.wsl
+        if: steps.wsl-cache.outputs.cache-hit != 'true'
+        run: curl --fail-with-body --location --output wsl-amd64.wsl "${WSL_IMAGE_URL}"
 
       - name: Run installer
         run: docker compose --file compose.ci.yml up --build --abort-on-container-exit --exit-code-from test-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,10 @@ jobs:
         id: wsl-image
         run: |
           etag=$(
-            curl --fail-with-body --silent --head --location "${WSL_IMAGE_URL}" |
-              awk -F': ' 'tolower($1) == "etag" { gsub(/\r/, "", $2); print $2; exit }'
+            curl --fail-with-body --silent --head --location \
+              --write-out '%header{etag}' \
+              --output /dev/null \
+              "${WSL_IMAGE_URL}"
           )
           etag="${etag//\"/}"
           if [[ -z ${etag} ]]; then


### PR DESCRIPTION
## Summary
- Cache the ~367MB `noble-wsl-amd64.wsl` artifact in the `test-linux` job using `actions/cache`, keyed on the remote ETag.
- Skip the full `curl` download when a matching cache entry exists, which avoids intermittent 8+ minute downloads from `cdimages.ubuntu.com`.

## Context
Recent CI runs showed the WSL image download step varying from ~3s to ~8m44s depending on runner-to-Ubuntu CDN throughput. The installer step itself stays around ~2 minutes.

## Test plan
- [ ] Confirm first run on this PR populates the cache (download step runs).
- [ ] Re-run CI and confirm cache hit skips the download.
- [ ] Verify `test-linux` still passes end-to-end.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Improve Linux CI job reliability and performance by caching the Ubuntu WSL test image and making its download conditional on cache misses.

CI:
- Introduce a fixed WSL image URL environment variable for the test-linux job.
- Add a step to resolve the Ubuntu WSL image ETag and use it as the cache key in actions/cache.
- Make the Ubuntu WSL image download step conditional on a cache miss to avoid repeated large downloads.