### PR TITLE
chore(wsl): hardcode git identity and ghr defaults in dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ This repository is organized around the two installer entry points:
     does not discover symlinked skill files.
   - `wsl/etc/` mirrors root-owned system files. The installer links these files
     into `/etc`.
-  - `wsl/setup-git.ts` performs interactive Git account setup after the base WSL
-    environment is ready.
+  - `wsl/setup-git.ts` performs interactive GitHub auth and GPG signing setup
+    after the base WSL environment is ready. Git identity and `ghr` defaults live
+    in `wsl/home/.gitconfig` and `wsl/home/.ghr/ghr.toml`.
 
 - `worker/` is a Cloudflare Worker for `dot.risunosu.com`. It redirects the root
   route to this README and serves the `/win` and `/wsl` installer routes by

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This repository is organized around the two installer entry points:
   - `wsl/etc/` mirrors root-owned system files. The installer links these files
     into `/etc`.
   - `wsl/setup-git.ts` performs interactive GitHub auth and GPG signing setup
-    after the base WSL environment is ready. Git identity and `ghr` defaults live
-    in `wsl/home/.gitconfig` and `wsl/home/.ghr/ghr.toml`.
+    after the base WSL environment is ready. Git identity and `ghr` defaults
+    live in `wsl/home/.gitconfig` and `wsl/home/.ghr/ghr.toml`.
 
 - `worker/` is a Cloudflare Worker for `dot.risunosu.com`. It redirects the root
   route to this README and serves the `/win` and `/wsl` installer routes by

--- a/wsl/home/.ghr/ghr.toml
+++ b/wsl/home/.ghr/ghr.toml
@@ -1,0 +1,1 @@
+defaults.owner = "risu729"

--- a/wsl/home/.gitconfig
+++ b/wsl/home/.gitconfig
@@ -1,6 +1,10 @@
 [init]
 	defaultBranch = main
 
+[user]
+	name = Taku Kodma
+	email = 79110363+risu729@users.noreply.github.com
+
 [fetch]
 	prune = true
 

--- a/wsl/setup-git.ts
+++ b/wsl/setup-git.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rmdir } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-import { $, env, spawn, write } from "bun";
+import { $, env, spawn } from "bun";
 
 /* oxlint-disable eslint/complexity eslint/max-depth eslint/max-lines-per-function eslint/max-statements eslint/max-params eslint/no-await-in-loop */
 
@@ -94,12 +94,6 @@ const ensureGitHubTokenScopes = async (): Promise<() => Promise<void>> => {
 			// Required to list, add, and delete GPG keys
 			scope: "admin:gpg_key",
 		},
-		{
-			generalScope: "user",
-			removeAfterUse: true,
-			// Required to get user email
-			scope: "user:email",
-		},
 	];
 
 	const removeScopes = async (): Promise<void> => {
@@ -165,37 +159,19 @@ const ghApi = async <ReturnType>(
 		.env(envWithoutGitHubToken)
 		.json();
 
-// GitHub CLI does not support setting user.name and user.email automatically
-// Ref: https://github.com/cli/cli/issues/6096
-const setGitUserConfig = async (): Promise<{
+const getGitIdentity = async (): Promise<{
 	githubId: string;
 	email: string;
 }> => {
-	// User scope is not required to get name and email
-	const { name, login } = await ghApi<{
-		name: string | null;
-		login: string;
-	}>("/user");
-	await $`git config --file ${localGitConfigPath} user.name ${name ?? login}`.quiet();
-
-	const noReplyEmail = await ghApi<{ email: string }[]>("/user/emails").then((emails) =>
-		emails.map(({ email }) => email).find((email) => email.endsWith("@users.noreply.github.com")),
-	);
-	if (!noReplyEmail) {
-		throw new Error("Failed to get GitHub-provided no-reply email");
+	const email = (await $`git config user.email`.text()).trim();
+	if (!email) {
+		throw new Error("user.email is not set in git config");
 	}
-	await $`git config --file ${localGitConfigPath} user.email ${noReplyEmail}`.quiet();
-	return { email: noReplyEmail, githubId: login };
-};
-
-const createGhrConfig = async (githubId: string): Promise<void> => {
-	const ghrHomeDir = (await $`ghr path`.text()).trim();
-	if (!ghrHomeDir) {
-		throw new Error("Failed to get ghr home directory");
+	const githubId = email.match(/^[^+]*\+([^@]+)@users\.noreply\.github\.com$/)?.[1];
+	if (!githubId) {
+		throw new Error(`Could not parse GitHub login from user.email: ${email}`);
 	}
-	const ghrConfigPath = resolve(ghrHomeDir, "ghr.toml");
-	const ghrConfig = `defaults.owner = "${githubId}"`;
-	await write(ghrConfigPath, ghrConfig);
+	return { email, githubId };
 };
 
 // Ref: https://github.com/gpg/gnupg/blob/master/doc/DETAILS#format-of-the-colon-listings
@@ -1225,8 +1201,7 @@ const main = async (): Promise<void> => {
 	const removeScopes = await ensureGitHubTokenScopes();
 
 	try {
-		const { githubId, email } = await setGitUserConfig();
-		await createGhrConfig(githubId);
+		const { githubId, email } = await getGitIdentity();
 		await configureGitSign(githubId, email);
 	} finally {
 		await removeScopes();

--- a/wsl/setup-git.ts
+++ b/wsl/setup-git.ts
@@ -126,10 +126,7 @@ const ensureGitHubTokenScopes = async (): Promise<() => Promise<void>> => {
 			.split(", ")
 			.map((scope) => scope.replaceAll(/'/g, "")) ?? [];
 	const missingScopes = requiredScopes
-		.filter(
-			({ scope, generalScope }) =>
-				!(scopes.includes(scope) || (generalScope && scopes.includes(generalScope))),
-		)
+		.filter(({ scope }) => !scopes.includes(scope))
 		.map(({ scope }) => scope);
 	if (missingScopes.length > 0) {
 		console.info(


### PR DESCRIPTION
## Summary
- Hardcode `user.name` and `user.email` in `wsl/home/.gitconfig`
- Add tracked `wsl/home/.ghr/ghr.toml` (symlinked to `~/.ghr/ghr.toml` by the installer)
- Simplify `wsl/setup-git.ts` to read identity from git config for GPG setup only; drop `user:email` OAuth scope and dynamic `ghr.toml` writes

## Test plan
- [ ] Fresh WSL install symlinks `~/.ghr/ghr.toml` correctly
- [ ] `setup-git.ts` still configures GPG signing using identity from `.gitconfig`
- [ ] `git config user.name` / `user.email` resolve from symlinked `.gitconfig`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Hardcode Git identity and ghr defaults in WSL dotfiles and update the Git setup script to rely on the existing Git config for GPG signing.

Enhancements:
- Simplify WSL Git setup to read user identity from git config instead of GitHub APIs and token scopes, and to use it solely for GPG signing configuration.

Documentation:
- Clarify README to describe that Git identity and ghr defaults are defined in tracked WSL dotfiles.

Chores:
- Add a tracked ghr configuration file under wsl/home/.ghr/ghr.toml with a default owner setting.