### PR TITLE
chore: remove linguist-generated from .gitignore in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 * text=auto eol=lf
-.gitignore linguist-generated=true
 tsconfig*.json linguist-language=JSON-with-Comments
 win/winget.json linguist-language=JSON-with-Comments
 .vscode/*.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
## Summary
- Remove `.gitignore linguist-generated=true` from `.gitattributes` so GitHub no longer excludes `.gitignore` from language statistics.

## Test plan
- [ ] Verify `.gitattributes` no longer contains the linguist-generated rule for `.gitignore`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Chores:
- Remove the linguist-generated rule for .gitignore from .gitattributes.