### PR TITLE
ci(workflows): remove mise lock autofix and stale locked flags

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -45,10 +45,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Regenerate lockfiles
-        if: ${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/') }}
-        run: mise lock --platform linux-x64
-
       - name: autofix.ci
         uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.6.12
-          install_args: --locked
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -149,7 +148,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.6.12
-          install_args: --locked
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
- Remove the Renovate-only `mise lock` step from autofix now that Renovate supports `mise.lock`
- Drop redundant `install_args: --locked` from `mise-action` steps in CI since `locked: true` is now the default

## Test plan
- [ ] CI passes on this PR
- [ ] Renovate PRs update `mise.lock` without relying on autofix


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Update CI workflows to rely on built-in mise lock handling and defaults instead of custom or redundant settings.

CI:
- Remove the Renovate-specific mise lock regeneration step from the autofix workflow.
- Drop explicit --locked install_args from mise-action steps now that locked mode is the default.