### PR TITLE
chore(mise): run hk install --mise in postinstall hook

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -62,5 +62,6 @@ includes = ["tasks.toml", "tasks", "worker/tasks.toml", "worker/tasks"]
 postinstall = """
 {% if env.CI is undefined %}
   mise run --no-deps install:ps-script-analyzer
+  hk install --mise
 {% endif %}
 """


### PR DESCRIPTION
## Summary
- Run `hk install --mise` in the mise `postinstall` hook alongside the existing PowerShell Script Analyzer install step
- Keeps the hook local-only (skipped in CI) so git hooks use `mise x` and hook tools are available without activating mise in the shell

## Test plan
- [ ] Run `mise install` locally and confirm `hk install --mise` completes without error
- [ ] Verify git hooks are configured (e.g. `git config --get-regexp '^hook\.hk-'`)
- [ ] Confirm a pre-commit hook run picks up mise-managed tools


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Chores:
- Extend the mise postinstall script to invoke `hk install --mise` alongside the existing PowerShell Script Analyzer installation.