### PR TITLE
chore(mise): remove obsolete HK_PKL_BACKEND env var

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -6,9 +6,6 @@ min_version = "2026.6.13"
 [vars]
 PS_SCRIPT_ANALYZER_VERSION = "1.25.0"
 
-[env]
-HK_PKL_BACKEND = "pklr"
-
 [tools]
 bun = "1.3.14"
 aube = "v1.24.0"


### PR DESCRIPTION
## Summary
- Remove the `HK_PKL_BACKEND = "pklr"` setting from `mise.toml`; hk no longer requires explicitly selecting the pklr backend.

## Test plan
- [ ] CI lint/check passes


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Chores:
- Clean up obsolete HK_PKL_BACKEND environment variable setting from the mise configuration.