### PR TITLE
chore(wsl): remove unattended-upgrades apt config

### DIFF
--- a/wsl/etc/apt/apt.conf.d/51unattended-upgrades
+++ b/wsl/etc/apt/apt.conf.d/51unattended-upgrades
@@ -1,6 +1,0 @@
-// ref: https://github.com/mvo5/unattended-upgrades/blob/master/README.md
-
-Unattended-Upgrade::Origins-Pattern {
-	// auto upgrades all packages
-	"origin=*";
-};


### PR DESCRIPTION
## Summary
- Remove `wsl/etc/apt/apt.conf.d/51unattended-upgrades`, which configured apt to auto-upgrade all packages on WSL.

## Test plan
- [ ] Confirm WSL installer still links remaining `wsl/etc/` files correctly


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Chores:
- Delete the WSL unattended-upgrades APT configuration file to stop automatic package upgrades in that environment.