### PR TITLE
chore: remove redundant bunfig.toml files

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,0 @@
-# ref: https://bun.sh/docs/runtime/bunfig
-
-[install]
-exact = true
-auto = "disable"

--- a/worker/bunfig.toml
+++ b/worker/bunfig.toml
@@ -1,5 +1,0 @@
-# ref: https://bun.sh/docs/runtime/bunfig
-
-[install]
-exact = true
-auto = "disable"


### PR DESCRIPTION
## Summary
- Remove the root `bunfig.toml`, which duplicated install settings
- Remove `worker/bunfig.toml` as well; the explicit `[install]` overrides are no longer needed

## Test plan
- [ ] `bun install` at repo root still behaves as expected
- [ ] `bun install` in `worker/` still behaves as expected

## Summary by Sourcery

Remove redundant Bun configuration files from the repository root and worker directory to rely on default or shared install settings.

Build:
- Delete the root bunfig.toml to eliminate duplicated install configuration.
- Delete worker/bunfig.toml now that custom install overrides are no longer required.