### PR TITLE
chore(vscode): remove stale workspace config entries

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,8 +7,7 @@
 		"bluebrown.yamlfmt",
 		"github.vscode-github-actions",
 		"mrmlnc.vscode-json5",
-		// cspell:ignore tamasfe
-		"tamasfe.even-better-toml",
+		"tombi-toml.tombi",
 		"mkhl.shfmt",
 		"timonwong.shellcheck",
 		"vitest.explorer",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
 		"editor.defaultFormatter": "mkhl.shfmt"
 	},
 	"[toml]": {
-		"editor.defaultFormatter": "tamasfe.even-better-toml"
+		"editor.defaultFormatter": "tombi-toml.tombi"
 	},
 
 	"[yaml][github-actions-workflow]": {
@@ -19,8 +19,6 @@
 	"editor.formatOnSave": true,
 
 	"files.associations": {
-		".czrc": "jsonc",
-		".tool-versions": "plaintext",
 		// match on the absolute path if / is contained
 		"**/tasks/**": "shellscript",
 		"**/wsl/etc/**": "plaintext",


### PR DESCRIPTION
## Summary
- Remove `files.associations` entries for `.czrc` and `.tool-versions`, which no longer exist in the repo
- Replace `tamasfe.even-better-toml` (taplo-based) with `tombi-toml.tombi` in workspace extension recommendations and TOML default formatter settings

## Test plan
- [ ] Open a `.toml` file in VS Code and confirm Tombi is suggested/used as the formatter
- [ ] Verify format-on-save still works for TOML files with the Tombi extension installed


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Clean up VS Code workspace configuration and update TOML tooling defaults.

Enhancements:
- Remove obsolete VS Code file association entries for configuration files that no longer exist in the repository.
- Update VS Code workspace extension recommendations and TOML formatter settings to use the Tombi TOML extension instead of the previous TOML extension.