### PR TITLE
ci: run test-linux setup steps in parallel

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/ci.yml:
+    ignore:
+      # actionlint v1.7.12 does not support GitHub Actions parallel steps yet.
+      - 'step must run script with "run" section or run action with "uses" section'
+      - 'property "wsl-image" is not defined in object type \{\}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,29 +57,30 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Prepare Docker Compose environment
-        run: |
-          mise_version=$(sed -n 's/^min_version = "\(.*\)"$/\1/p' mise.toml)
-          if [[ -z ${mise_version} ]]; then
-            echo "Failed to read mise min_version." >&2
-            exit 1
-          fi
-          echo "MISE_VERSION=${mise_version}" >> "${GITHUB_ENV}"
-      - name: Resolve Ubuntu WSL image version
-        id: wsl-image
-        run: |
-          etag=$(
-            curl --fail-with-body --silent --head --location \
-              --write-out '%header{etag}' \
-              --output /dev/null \
-              "${WSL_IMAGE_URL}"
-          )
-          etag="${etag//\"/}"
-          if [[ -z ${etag} ]]; then
-            echo "Failed to read WSL image ETag." >&2
-            exit 1
-          fi
-          echo "etag=${etag}" >> "${GITHUB_OUTPUT}"
+      - parallel:
+          - name: Prepare Docker Compose environment
+            run: |
+              mise_version=$(sed -n 's/^min_version = "\(.*\)"$/\1/p' mise.toml)
+              if [[ -z ${mise_version} ]]; then
+                echo "Failed to read mise min_version." >&2
+                exit 1
+              fi
+              echo "MISE_VERSION=${mise_version}" >> "${GITHUB_ENV}"
+          - name: Resolve Ubuntu WSL image version
+            id: wsl-image
+            run: |
+              etag=$(
+                curl --fail-with-body --silent --head --location \
+                  --write-out '%header{etag}' \
+                  --output /dev/null \
+                  "${WSL_IMAGE_URL}"
+              )
+              etag="${etag//\"/}"
+              if [[ -z ${etag} ]]; then
+                echo "Failed to read WSL image ETag." >&2
+                exit 1
+              fi
+              echo "etag=${etag}" >> "${GITHUB_OUTPUT}"
       - name: Cache Ubuntu WSL image
         id: wsl-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
## Summary

- Run the independent `test-linux` setup steps as a GitHub Actions `parallel` group.
- Add a scoped actionlint ignore for `ci.yml` while actionlint v1.7.12 does not recognize the new `parallel` syntax yet.

This uses the GitHub Actions parallel steps feature announced in the changelog: https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/

## Upstream linter status

- `actionlint` v1.7.12 does not support parallel steps yet. Support is tracked in [issue #693](https://github.com/rhysd/actionlint/issues/693) and implementation PRs [#694](https://github.com/rhysd/actionlint/pull/694) and [#695](https://github.com/rhysd/actionlint/pull/695). The scoped ignore remains necessary until support is merged and released.
- `zizmor` support was tracked in [issue #2151](https://github.com/zizmorcore/zizmor/issues/2151) and implemented by PRs [#2153](https://github.com/zizmorcore/zizmor/pull/2153) and [#2156](https://github.com/zizmorcore/zizmor/pull/2156). Experimental support is available in [v1.27.0](https://github.com/zizmorcore/zizmor/releases/tag/v1.27.0), which this branch uses.

## Validation

- `mise run check --lint`

## Summary by Sourcery

Run independent test-linux setup steps in the CI workflow in parallel and adjust linting configuration to accommodate the new workflow syntax.

CI:
- Group the Docker Compose preparation and Ubuntu WSL image resolution steps into a parallel block in the test-linux job of ci.yml.
- Add an actionlint configuration file to ignore temporary false positives caused by the new parallel steps syntax in ci.yml.
