### PR TITLE
fix(mise): parse codex-tmux task metadata

### DIFF
--- a/wsl/home/.config/mise/tasks/codex-tmux
+++ b/wsl/home/.config/mise/tasks/codex-tmux
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2310 # fallback functions intentionally return status
-#MISE description "Launch Codex CLI in a tmux-backed Worktrunk worktree"
+#MISE description="Launch Codex CLI in a tmux-backed Worktrunk worktree"
 #MISE dir="{{cwd}}"
 #USAGE about "Launch Codex in a tmux-backed Worktrunk checkout"
 #USAGE arg "[repo]" help="ghr repo name, host:owner/repo, or owner/repo" required=#false


### PR DESCRIPTION
## Summary
- fix the codex-tmux task metadata to use mise key=value syntax
- restore parsing of the task description and usage spec

## Verification
- `mise task info codex-tmux`
- `mise tasks ls`
- commit hooks

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect metadata format in the codex-tmux mise task that prevented proper parsing of description and usage information.