### PR TITLE
fix(mise): refresh pitchfork boot registration

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -56,7 +56,7 @@ kubectx = "latest"
 kubeseal = "latest"
 mitmproxy = "latest"
 doggo = "latest"
-pitchfork = "latest"
+pitchfork = { version = "latest", postinstall = "pitchfork boot disable || true; pitchfork boot enable" }
 miller = "latest"
 glow = "latest"
 "github:garden-rs/garden" = "latest"


### PR DESCRIPTION
## Summary

- Change the global mise pitchfork tool entry to use a per-tool `postinstall` hook.
- Refresh pitchfork boot registration after pitchfork itself is installed by running `pitchfork boot disable || true; pitchfork boot enable`.

## Why

The pitchfork boot service can keep pointing at an older mise-managed install path after pitchfork upgrades. Refreshing the registration as part of pitchfork's own install keeps the systemd user service aligned without calling `systemctl` directly from the mise config.

## Validation

- `python3` TOML parse check for `wsl/home/.config/mise/config.toml`
- commit hooks: `tombi format --check --diff`, `tombi lint --error-on-warnings`, `betterleaks`, `typos`, newline and file hygiene checks

Note: an initial `mise x taplo` check was blocked by repo dependency setup hitting existing Bun links before taplo ran; the commit hooks then ran the repo TOML checks successfully.

## Summary by Sourcery

Enhancements:
- Update the mise pitchfork tool configuration to use a per-tool postinstall hook for boot service refresh instead of relying on the previous global entry.