### PR TITLE
ci: align CI Check guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,14 +160,12 @@ jobs:
       - test-linux
       - test-worker
     # ref: https://github.com/aquaproj/aqua-registry/pull/38449#issuecomment-3038859524
-    if: always()
+    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:
-      - name: Fail CI Check
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: exit 1
+      - run: exit 1
 
   actions-timeline:
     name: Generate Actions Timeline


### PR DESCRIPTION
## Summary

- Move the `CI Check` failure/cancelled condition from the failing step to the `ci-check` job `if:` guard.
- Keep the job behavior aligned with the other active repositories using this pattern.

## Validation

- Staged pre-commit checks passed for `.github/workflows/ci.yml`.
- Workflow-specific checks passed: `actionlint`, `zizmor`, `ghalint`, `yamlfmt`, and `yamllint` on `.github/workflows/ci.yml`.
- `mise run check --lint` was attempted, but the local full-repo check failed on unrelated TypeScript steps because `tsc` was not available in the local environment.

## Summary by Sourcery

CI:
- Update the ci-check workflow job to only run and fail when upstream jobs are failed or cancelled, instead of guarding the failure step itself.