### PR TITLE
chore: remove zizmor GH_TOKEN shim

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -12,7 +12,6 @@ hk \
   {% if usage.lint %}check{% else %}fix{% endif %} \
   --all --no-progress --no-fail-fast
 """
-env.GH_TOKEN = "{% if env.GITHUB_TOKEN is defined %}{{ env.GITHUB_TOKEN }}{% endif %}"
 description = "Run hk linters and formatters."
 
 ["install:ps-script-analyzer"]


### PR DESCRIPTION
## Summary

- Remove the `GH_TOKEN` task-level shim from `tasks.toml`.
- Let zizmor read `GITHUB_TOKEN` directly now that the pinned version supports it.

## Related

- Same cleanup in mikoto: https://github.com/risu729/mikoto/pull/67

## Validation

- Staged pre-commit checks passed for `tasks.toml`.
- `mise run check --lint` was attempted; the workflow and zizmor checks passed before the local full check failed later on unrelated TypeScript steps because `tsc` was not available on PATH.