### PR TITLE
ci: trim redundant token env

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -36,8 +36,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.7.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run autofix
         run: mise run --continue-on-error check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.7.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run check
         if: github.event_name != 'schedule'
@@ -145,8 +143,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.7.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run tests
         run: mise run worker:test


### PR DESCRIPTION
## Summary

- Remove redundant `GITHUB_TOKEN` env entries from `jdx/mise-action` install steps.
- Keep `GITHUB_TOKEN` on the lint, test, and autofix execution steps that can actually use it.

## Related

- Same cleanup in mikoto: https://github.com/risu729/mikoto/pull/67

## Validation

- Staged pre-commit checks passed for the changed workflow files.
- `mise run check --lint` was attempted; actionlint, pinact, zizmor, ghalint, yaml, and other workflow-adjacent checks passed before the local full check failed later on unrelated TypeScript steps because `tsc` was not available on PATH.

## Summary by Sourcery

CI:
- Simplify CI and autofix workflows by dropping unnecessary GITHUB_TOKEN env entries from jdx/mise-action install steps.