### PR TITLE
fix(mise): paginate Renovate PR query

### DIFF
--- a/wsl/home/.config/mise/tasks/renovate-prs
+++ b/wsl/home/.config/mise/tasks/renovate-prs
@@ -103,8 +103,12 @@ exclusions_json() {
 
 graphql_query() {
 	cat <<'GRAPHQL'
-query($searchQuery: String!) {
-  search(type: ISSUE, query: $searchQuery, first: 100) {
+query($searchQuery: String!, $cursor: String) {
+  search(type: ISSUE, query: $searchQuery, first: 20, after: $cursor) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
     nodes {
       ... on PullRequest {
         mergeable
@@ -140,12 +144,26 @@ search_query() {
 }
 
 fetch_prs() {
+	local all_nodes='[]'
+	local cursor
+	local has_next_page=true
+	local page
+	local page_count=0
 	local query
 	local search
 
 	query=$(graphql_query)
 	search=$(search_query)
-	gh api graphql -f query="${query}" -f searchQuery="${search}"
+
+	while [[ ${has_next_page} == true && ${page_count} -lt 5 ]]; do
+		page=$(gh api graphql -f query="${query}" -f searchQuery="${search}" -F cursor="${cursor:-}")
+		all_nodes=$(jq -c --argjson nodes "${all_nodes}" '$nodes + .data.search.nodes' <<<"${page}")
+		cursor=$(jq -r '.data.search.pageInfo.endCursor // empty' <<<"${page}")
+		has_next_page=$(jq -r '.data.search.pageInfo.hasNextPage' <<<"${page}")
+		((page_count += 1))
+	done
+
+	jq -cn --argjson nodes "${all_nodes}" '{data: {search: {nodes: $nodes}}}'
 }
 
 pr_rows() {


### PR DESCRIPTION
## Summary

- fetch Renovate PR search results in pages of 20
- preserve the existing 100-result limit and output format
- avoid GitHub GraphQL timeouts caused by resolving merge and check state for 100 PRs in one request

## Root cause

The task requested up to 100 pull requests together with computed `mergeable`, `mergeStateStatus`, and `statusCheckRollup` fields in a single GraphQL request. GitHub can terminate that expensive request with a 502 when it exceeds the GraphQL processing timeout.

## Validation

- `bash -n wsl/home/.config/mise/tasks/renovate-prs`
- `shellcheck wsl/home/.config/mise/tasks/renovate-prs`
- `wsl/home/.config/mise/tasks/renovate-prs`
- `mise run check --lint`

## Summary by Sourcery

Paginate the GitHub GraphQL query used by the `renovate-prs` mise task to avoid timeouts while preserving the existing 100-result limit and output format.

Bug Fixes:
- Prevent GitHub GraphQL 502 errors when fetching merge and check state for large batches of Renovate pull requests.

Enhancements:
- Update the `renovate-prs` task to retrieve Renovate pull request search results in smaller pages while maintaining the overall limit of results.