### PR TITLE
feat(mise): enable native cargo binstall

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -101,6 +101,7 @@ sccache = "latest"
 [settings]
 experimental = true
 minimum_release_age = "3h"
+cargo.binstall_native = true
 
 [settings.npm]
 package_manager = "aube"


### PR DESCRIPTION
## Summary

- enable mise’s native Cargo binary installer globally
- retain Cargo source-install fallback when a compatible binary artifact is unavailable

## Validation

- `mise x taplo -- taplo check wsl/home/.config/mise/config.toml`
- `git diff --check`