### PR TITLE
refactor(hk): merge shell selectors

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -1,8 +1,16 @@
-amends "https://raw.githubusercontent.com/risu729/hk-config/v1.0.0/presets.pkl"
+amends
+  "https://raw.githubusercontent.com/risu729/hk-config/a34802b174b5a1f669dbd09fb6301f7eca7a5770/presets.pkl"
 
-import "https://raw.githubusercontent.com/risu729/hk-config/v1.0.0/helpers.pkl"
+import
+  "https://raw.githubusercontent.com/risu729/hk-config/a34802b174b5a1f669dbd09fb6301f7eca7a5770/helpers.pkl"
 
 local const bashrcGlobs = List("wsl/home/.bashrc")
+
+local function includeBashrc(step: Step): Step = (step) {
+  match_any =
+    step.match_any!!
+      + List(new FileSelector { glob = bashrcGlobs })
+}
 
 local picked =
   helpers.pick(new Listing {
@@ -48,12 +56,8 @@ local worker = new Group {
 
 hooks =
   helpers.standardHooks((picked) {
-    ["shfmt-bashrc"] = (picked["shfmt"]) {
-      glob = bashrcGlobs
-    }
-    ["shellcheck-bashrc"] = (picked["shellcheck"]) {
-      glob = bashrcGlobs
-    }
+    ["shfmt"] = includeBashrc(picked["shfmt"] as Step)
+    ["shellcheck"] = includeBashrc(picked["shellcheck"] as Step)
     ["mise"] = (mise) {
       steps {
         ["mise-fmt"] = mise.steps["mise-fmt"]


### PR DESCRIPTION
## Summary

- extend the hk v1.51 `shfmt` and `shellcheck` builtin `match_any` selectors with `wsl/home/.bashrc`
- replace the separate `shfmt-bashrc` and `shellcheck-bashrc` steps with the original catalog step keys
- temporarily pin hk-config to immutable commit `a34802b174b5a1f669dbd09fb6301f7eca7a5770`, which contains the hk v1.51 schema

## Why

hk v1.51 adds disjunctive selectors to the shell builtins. Appending the non-shebang `.bashrc` path to those selectors preserves extension and shebang matching while avoiding duplicate tool invocations.

The published hk-config v1.0.0 tag still uses hk v1.48 and cannot parse `match_any`. This draft must stay blocked until the pinned hk-config commit is released; replace the commit SHA URLs with that release tag before merge.

## Validation

- `pkl format --write hk.pkl`
- `pkl eval hk.pkl`
- `hk validate` with hk 1.51.0
- `hk test --step shfmt`
- `hk test --step shellcheck`
- verified the resolved check hook has one `shfmt` and one `shellcheck` step, each with the two builtin clauses plus the `.bashrc` clause

## Summary by Sourcery

Refine hk shell formatting and linting hooks to include .bashrc via shared selectors while temporarily pinning the hk-config preset/import to a specific commit compatible with hk v1.51.

Enhancements:
- Add a reusable helper to extend shell steps with an additional .bashrc file selector, consolidating configuration for shfmt and shellcheck.
- Merge the separate shfmt-bashrc and shellcheck-bashrc hooks back into the primary shfmt and shellcheck steps to avoid duplicate tool invocations.

Build:
- Pin hk.pkl presets and helpers imports to a specific hk-config commit that includes the hk v1.51 schema, to support match_any-based selectors until a new release tag is available.