### PR TITLE
refactor(mise): configure Docker repository in bootstrap

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -64,7 +64,7 @@ sudo install --directory --mode=0755 /etc/apt/keyrings
 
 arch=$(dpkg --print-architecture)
 # shellcheck source=/dev/null
-codename=$(source /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME}}")
+codename=$(. /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME}}")
 
 # ref: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
 curl --fail-with-body --silent --show-error --location https://download.docker.com/linux/ubuntu/gpg |

--- a/mise.toml
+++ b/mise.toml
@@ -73,30 +73,6 @@ echo "deb [arch=${arch} signed-by=/etc/apt/keyrings/docker.asc] https://download
   sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
 '''
 
-[bootstrap.packages]
-"apt:bubblewrap" = "latest"
-"apt:build-essential" = "latest"
-"apt:clang" = "latest"
-"apt:clangd" = "latest"
-"apt:clang-format" = "latest"
-"apt:cmake" = "latest"
-"apt:containerd.io" = "latest"
-"apt:desktop-file-utils" = "latest"
-"apt:docker-buildx-plugin" = "latest"
-"apt:docker-ce" = "latest"
-"apt:docker-ce-cli" = "latest"
-"apt:docker-compose-plugin" = "latest"
-"apt:ffmpeg" = "latest"
-"apt:gdb" = "latest"
-"apt:graphviz" = "latest"
-"apt:libssl-dev" = "latest"
-"apt:llvm" = "latest"
-"apt:parallel" = "latest"
-"apt:pkg-config" = "latest"
-"apt:strace" = "latest"
-"apt:xdg-utils" = "latest"
-"apt:zip" = "latest"
-
 [bootstrap.hooks.post-packages]
 run = '''
 username=$(whoami)
@@ -127,6 +103,30 @@ if [ -t 0 ] && [ -t 1 ]; then
   fi
 fi
 '''
+
+[bootstrap.packages]
+"apt:bubblewrap" = "latest"
+"apt:build-essential" = "latest"
+"apt:clang" = "latest"
+"apt:clangd" = "latest"
+"apt:clang-format" = "latest"
+"apt:cmake" = "latest"
+"apt:containerd.io" = "latest"
+"apt:desktop-file-utils" = "latest"
+"apt:docker-buildx-plugin" = "latest"
+"apt:docker-ce" = "latest"
+"apt:docker-ce-cli" = "latest"
+"apt:docker-compose-plugin" = "latest"
+"apt:ffmpeg" = "latest"
+"apt:gdb" = "latest"
+"apt:graphviz" = "latest"
+"apt:libssl-dev" = "latest"
+"apt:llvm" = "latest"
+"apt:parallel" = "latest"
+"apt:pkg-config" = "latest"
+"apt:strace" = "latest"
+"apt:xdg-utils" = "latest"
+"apt:zip" = "latest"
 
 [bootstrap.user]
 login_shell = "/bin/bash"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,7 @@
 # ref: https://mise.jdx.dev/configuration.html
 #:schema https://mise.jdx.dev/schema/mise.json
+# TODO: Remove when the mise schema includes bootstrap hooks.
+#:tombi schema.strict = false
 
 min_version = "2026.7.6"
 
@@ -55,6 +57,21 @@ run = "bun install --frozen-lockfile"
 
 [task_config]
 includes = ["tasks.toml", "tasks", "worker/tasks.toml", "worker/tasks"]
+
+[bootstrap.hooks.pre-packages]
+run = '''
+sudo install --directory --mode=0755 /etc/apt/keyrings
+
+arch=$(dpkg --print-architecture)
+# shellcheck source=/dev/null
+codename=$(source /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME}}")
+
+# ref: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
+curl --fail-with-body --silent --show-error --location https://download.docker.com/linux/ubuntu/gpg |
+  sudo tee /etc/apt/keyrings/docker.asc >/dev/null
+echo "deb [arch=${arch} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu ${codename} stable" |
+  sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+'''
 
 [bootstrap.packages]
 "apt:bubblewrap" = "latest"

--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -24,28 +24,12 @@ log_error() {
 	echo -e "${RED}ERROR: $1${RESET}" >&2
 }
 
-install_custom_registry_packages() {
-	log_info "Setting up custom APT repositories and installing mise..."
-
-	sudo install --directory --mode=0755 /etc/apt/keyrings
-
-	local arch codename
-	arch="$(dpkg --print-architecture)"
-	# shellcheck source=/dev/null
-	codename="$(source /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME}}")"
-
+install_mise() {
 	log_info "Adding mise PPA..."
 	# ref: https://mise.jdx.dev/installing-mise.html#apt
 	sudo add-apt-repository --yes --no-update ppa:jdxcode/mise
 
-	log_info "Adding Docker APT repository..."
-	# ref: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
-	curl --fail-with-body --silent --show-error --location https://download.docker.com/linux/ubuntu/gpg |
-		sudo tee /etc/apt/keyrings/docker.asc >/dev/null
-	echo "deb [arch=${arch} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu ${codename} stable" |
-		sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
-
-	log_info "All repositories set up. Installing mise..."
+	log_info "Installing mise..."
 	sudo apt-get update
 	sudo apt-get install --yes mise
 	log_info "mise installed."
@@ -184,7 +168,7 @@ create_etc_symlinks() {
 }
 
 main() {
-	install_custom_registry_packages
+	install_mise
 
 	local dotfiles_dir
 	dotfiles_dir=$(clone_or_update_dotfiles_repo "${repo_name}" "${git_ref}")


### PR DESCRIPTION
## Summary

- move Docker APT repository configuration into the mise `pre-packages` bootstrap hook
- keep only mise's own repository and installation in the WSL launcher
- let the existing `mise bootstrap --update` refresh Docker package metadata before package installation
- temporarily disable strict unknown-key checks for `mise.toml` because the published mise schema does not yet describe supported bootstrap hooks

## Why

Docker's repository is a prerequisite for the declarative Docker packages, so it belongs immediately before the bootstrap package phase rather than in the launcher that installs mise itself.

## Impact

The WSL launcher has a narrower responsibility while fresh and repeated bootstrap runs continue to configure Docker before installing its packages.

## Validation

- `mise bootstrap --only packages --dry-run --yes`
- `mise run check --lint`

## Summary by Sourcery

Move Docker APT repository configuration from the WSL launcher into a mise bootstrap hook so Docker is set up during the pre-packages phase while keeping the launcher focused on installing mise.

Enhancements:
- Introduce a mise `bootstrap.hooks.pre-packages` script to configure the Docker APT repository before declarative package installation.
- Simplify the WSL install script by limiting it to adding the mise PPA and installing mise.