### PR TITLE
refactor(mise): split bootstrap setup into phase hooks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,7 @@
 # ref: https://mise.jdx.dev/configuration.html
 #:schema https://mise.jdx.dev/schema/mise.json
+# TODO: Remove when the mise schema includes bootstrap hooks.
+#:tombi schema.strict = false
 
 min_version = "2026.7.6"
 
@@ -55,6 +57,37 @@ run = "bun install --frozen-lockfile"
 
 [task_config]
 includes = ["tasks.toml", "tasks", "worker/tasks.toml", "worker/tasks"]
+
+[bootstrap.hooks.post-packages]
+run = '''
+username=$(whoami)
+if ! groups "${username}" | grep --quiet --word-regexp docker; then
+  sudo usermod --append --groups docker "${username}"
+fi
+'''
+
+[bootstrap.hooks.post-dotfiles]
+run = '''
+mkdir --parents "${HOME}/.gnupg"
+chmod 700 "${HOME}/.gnupg"
+sudo update-desktop-database
+'''
+
+[bootstrap.hooks.post-tools]
+run = '''
+# Installing this before the tools phase makes Git use gh before gh is installed.
+ln --symbolic --no-dereference --force \
+  "${MISE_PROJECT_ROOT}/wsl/home/.gitconfig" "${HOME}/.gitconfig"
+'''
+
+[bootstrap.hooks.final]
+run = '''
+if [ -t 0 ] && [ -t 1 ]; then
+  if ! mise exec -- bash --interactive -c "${MISE_PROJECT_ROOT}/wsl/setup-git.ts"; then
+    echo "Git setup failed; run wsl/setup-git.ts manually if needed." >&2
+  fi
+fi
+'''
 
 [bootstrap.packages]
 "apt:bubblewrap" = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -58,6 +58,30 @@ run = "bun install --frozen-lockfile"
 [task_config]
 includes = ["tasks.toml", "tasks", "worker/tasks.toml", "worker/tasks"]
 
+[bootstrap.packages]
+"apt:bubblewrap" = "latest"
+"apt:build-essential" = "latest"
+"apt:clang" = "latest"
+"apt:clangd" = "latest"
+"apt:clang-format" = "latest"
+"apt:cmake" = "latest"
+"apt:containerd.io" = "latest"
+"apt:desktop-file-utils" = "latest"
+"apt:docker-buildx-plugin" = "latest"
+"apt:docker-ce" = "latest"
+"apt:docker-ce-cli" = "latest"
+"apt:docker-compose-plugin" = "latest"
+"apt:ffmpeg" = "latest"
+"apt:gdb" = "latest"
+"apt:graphviz" = "latest"
+"apt:libssl-dev" = "latest"
+"apt:llvm" = "latest"
+"apt:parallel" = "latest"
+"apt:pkg-config" = "latest"
+"apt:strace" = "latest"
+"apt:xdg-utils" = "latest"
+"apt:zip" = "latest"
+
 [bootstrap.hooks.post-packages]
 run = '''
 username=$(whoami)
@@ -88,30 +112,6 @@ if [ -t 0 ] && [ -t 1 ]; then
   fi
 fi
 '''
-
-[bootstrap.packages]
-"apt:bubblewrap" = "latest"
-"apt:build-essential" = "latest"
-"apt:clang" = "latest"
-"apt:clangd" = "latest"
-"apt:clang-format" = "latest"
-"apt:cmake" = "latest"
-"apt:containerd.io" = "latest"
-"apt:desktop-file-utils" = "latest"
-"apt:docker-buildx-plugin" = "latest"
-"apt:docker-ce" = "latest"
-"apt:docker-ce-cli" = "latest"
-"apt:docker-compose-plugin" = "latest"
-"apt:ffmpeg" = "latest"
-"apt:gdb" = "latest"
-"apt:graphviz" = "latest"
-"apt:libssl-dev" = "latest"
-"apt:llvm" = "latest"
-"apt:parallel" = "latest"
-"apt:pkg-config" = "latest"
-"apt:strace" = "latest"
-"apt:xdg-utils" = "latest"
-"apt:zip" = "latest"
 
 [bootstrap.user]
 login_shell = "/bin/bash"

--- a/tasks.toml
+++ b/tasks.toml
@@ -14,30 +14,6 @@ hk \
 """
 description = "Run hk linters and formatters."
 
-[bootstrap]
-description = "Finish idempotent WSL user setup after packages, dotfiles, and tools are installed."
-run = '''
-mkdir --parents "${HOME}/.gnupg"
-chmod 700 "${HOME}/.gnupg"
-
-username=$(whoami)
-if ! groups "${username}" | grep --quiet --word-regexp docker; then
-  sudo usermod --append --groups docker "${username}"
-fi
-
-sudo update-desktop-database
-
-# Installing this before the tools phase makes Git use gh before gh is installed.
-ln --symbolic --no-dereference --force \
-  "${MISE_PROJECT_ROOT}/wsl/home/.gitconfig" "${HOME}/.gitconfig"
-
-if [[ -t 0 && -t 1 ]]; then
-  if ! bash --interactive -c "${MISE_PROJECT_ROOT}/wsl/setup-git.ts"; then
-    echo "Git setup failed; run wsl/setup-git.ts manually if needed." >&2
-  fi
-fi
-'''
-
 ["install:ps-script-analyzer"]
 shell = "pwsh -Command"
 # Force is required to bypass untrusted repository confirmation


### PR DESCRIPTION
## Summary

- replace the catch-all `bootstrap` task with phase-specific mise bootstrap hooks
- configure Docker group membership after packages
- repair GnuPG permissions and refresh desktop entries after dotfiles
- defer `.gitconfig` until tools are installed
- run interactive Git setup as the final bootstrap hook with mise tools on `PATH`
- temporarily disable strict unknown-key checks for `mise.toml` because the published mise schema does not yet describe supported bootstrap hooks

## Why

Each setup action has a specific ordering dependency. Encoding those dependencies in mise's bootstrap phases makes the lifecycle explicit and removes the monolithic final task.

## Impact

Bootstrap behavior remains idempotent, while setup actions run immediately after the resources they depend on become available.

## Validation

- `mise bootstrap --dry-run --yes`
- `mise run check --lint`

## Summary by Sourcery

Refactor WSL bootstrap into phase-specific mise hooks tied to package, dotfiles, tools, and final setup steps.

Enhancements:
- Split the monolithic bootstrap task into mise bootstrap phase hooks for post-packages, post-dotfiles, post-tools, and final stages.
- Adjust the ordering of Docker group configuration, GnuPG setup, desktop database refresh, and .gitconfig linking to align with their dependent resources.
- Run interactive Git configuration only in the final bootstrap phase with mise tools available on PATH.
- Temporarily relax strict schema validation for mise.toml to accommodate bootstrap hooks not yet covered by the official schema.