### PR TITLE
refactor(mise): manage WSL environment variables

### DIFF
--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -65,9 +65,6 @@ if [[ -x /usr/bin/dircolors ]]; then
 	eval "${dircolors}"
 fi
 
-# Colored GCC warnings and errors
-export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
-
 # Enable programmable completion features
 if ! shopt -oq posix && [[ -f /usr/share/bash-completion/bash_completion ]]; then
 	# shellcheck source=/dev/null
@@ -363,12 +360,6 @@ if [[ -z ${__CI:-} ]] && command -v gh &>/dev/null; then
 	# Suppress error
 	GITHUB_TOKEN=$(gh auth token 2>/dev/null)
 	export GITHUB_TOKEN
-fi
-
-# xdg-open
-# use powershell instead of pwsh as pwsh is not in the PATH sometimes
-if command -v powershell.exe &>/dev/null; then
-	export BROWSER="powershell.exe -c Start-Process"
 fi
 
 # antigravity

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -5,6 +5,10 @@
 RUSTC_WRAPPER = "sccache"
 # disable bat paging
 BAT_PAGING = "never"
+# use powershell instead of pwsh as pwsh is not in the PATH sometimes
+BROWSER = "powershell.exe -c Start-Process"
+# colored GCC warnings and errors
+GCC_COLORS = "error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01"
 _.path = ["~/.local/bin"]
 
 [tools]


### PR DESCRIPTION
## Summary

- move `BROWSER` and `GCC_COLORS` from interactive Bash startup into the global mise environment
- retain shell-specific prompt, completion, history, and runtime initialization in `.bashrc`

## Why

These values are environment configuration rather than interactive shell behavior. Managing them through mise makes them available consistently to interactive shells and commands launched through the mise environment.

## Impact

WSL commands receive the same browser command and GCC color settings without duplicating them in Bash-specific startup logic.

## Validation

- `mise env --shell bash | rg '^(export )?(BROWSER|GCC_COLORS)='`
- `mise run check --lint`

## Summary by Sourcery

Enhancements:
- Centralize BROWSER and GCC_COLORS configuration in mise so they apply consistently across WSL shells and commands.