### PR TITLE
refactor(mise): manage WSL login shell

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -80,6 +80,9 @@ includes = ["tasks.toml", "tasks", "worker/tasks.toml", "worker/tasks"]
 "apt:xdg-utils" = "latest"
 "apt:zip" = "latest"
 
+[bootstrap.user]
+login_shell = "/bin/bash"
+
 [dotfiles]
 "~/.agents" = { source = "wsl/home/.agents", mode = "copy" }
 "~/.bashrc" = "wsl/home/.bashrc"

--- a/win/install.ps1
+++ b/win/install.ps1
@@ -341,8 +341,7 @@ function New-WslUser {
 	)
 
 	# No need to check the duplicate username because useradd will fail if it exists
-	# The default shell is /bin/sh so override it with /bin/bash
-	Invoke-WSLCommand -Root -Command "useradd --create-home --shell /bin/bash $Username"
+	Invoke-WSLCommand -Root -Command "useradd --create-home $Username"
 	Invoke-WSLCommand -Root -Command "echo ${Username}:$Password | chpasswd"
 	Invoke-WSLCommand -Root -Command "usermod --append --groups sudo $Username"
 


### PR DESCRIPTION
## Summary

- declare `/bin/bash` as the desired WSL login shell through `[bootstrap.user]`
- remove the duplicate shell selection from Windows-side `useradd`

## Why

Setting the shell only when the account is created does not correct later drift. Mise can inspect and converge the current user's login shell on every explicit bootstrap run.

## Impact

Fresh WSL users are initially created with the platform default and then converged to Bash during bootstrap. Existing users are repaired if their configured login shell changes.

## Validation

- `mise bootstrap user status --json`
- `mise bootstrap --only user --dry-run --yes`
- `mise run check --lint`

## Summary by Sourcery

Declare and manage the WSL login shell via mise bootstrap configuration instead of hardcoding it in the Windows installer script.

Enhancements:
- Configure the desired WSL login shell in mise.toml under the bootstrap.user section to allow ongoing convergence.
- Simplify WSL user creation in the Windows install script by relying on mise bootstrap to set the login shell instead of useradd.