### PR TITLE
refactor(wsl): skip system package maintenance

### DIFF
--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -24,15 +24,6 @@ log_error() {
 	echo -e "${RED}ERROR: $1${RESET}" >&2
 }
 
-update_system_packages() {
-	log_info "Updating system packages..."
-	sudo apt-get update
-	sudo apt-get full-upgrade --yes
-	sudo apt-get autoremove --yes
-	sudo apt-get autoclean --yes
-	log_info "System packages updated."
-}
-
 install_custom_registry_packages() {
 	log_info "Setting up custom APT repositories and installing mise..."
 
@@ -197,7 +188,6 @@ create_etc_symlinks() {
 }
 
 main() {
-	update_system_packages
 	install_custom_registry_packages
 
 	local dotfiles_dir


### PR DESCRIPTION
## Summary

- remove the WSL installer's standalone APT update, full upgrade, autoremove, and autoclean phase
- retain the metadata refresh required immediately before installing mise
- continue using `mise bootstrap --update` for declared bootstrap packages

## Why

A dotfiles installation should provision its declared dependencies without performing unrelated operating-system upgrades or cleanup. The remaining install and bootstrap commands already refresh the package metadata they consume.

## Impact

Running the WSL installer no longer upgrades or removes unrelated system packages, reducing installation time and avoiding broad machine changes.

## Validation

- `bash -n wsl/install.sh`
- `mise run check --lint`

## Summary by Sourcery

Enhancements:
- Stop running full system APT upgrade and cleanup as part of the WSL install flow to avoid unrelated OS changes.