### PR TITLE
feat(wsl): upgrade to Ubuntu 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,8 @@ jobs:
       contents: read # for checkout
     env:
       COMPOSE_PROJECT_NAME: dotfiles-ci-${{ github.run_id }}-${{ github.run_attempt }}
-      # Keep WSL image target stable because newest LTS metadata can
-      # appear before cdimages publishes the corresponding wsl artifact.
-      WSL_IMAGE_URL: https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/current/noble-wsl-amd64.wsl
+      # Match the Ubuntu release installed by win/install.ps1.
+      WSL_IMAGE_URL: https://cdimages.ubuntu.com/ubuntu-wsl/resolute/daily-live/current/resolute-wsl-amd64.wsl
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -86,7 +85,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: wsl-amd64.wsl
-          key: ubuntu-wsl-noble-${{ steps.wsl-image.outputs.etag }}
+          key: ubuntu-wsl-resolute-${{ steps.wsl-image.outputs.etag }}
       - name: Download Ubuntu WSL image
         if: steps.wsl-cache.outputs.cache-hit != 'true'
         run: curl --fail-with-body --location --output wsl-amd64.wsl "${WSL_IMAGE_URL}"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Personal configuration for my Windows and WSL development environments.
 ## ⭐ Description
 
 These dotfiles are used to configure my environment, mainly Windows 11 and WSL2
-(Ubuntu).
+(Ubuntu 26.04 LTS).
 
 Since I use WSL2 as my main development environment, I only install GUI
 applications on Windows, such as browsers, IDEs, etc.

--- a/lychee.toml
+++ b/lychee.toml
@@ -30,9 +30,6 @@ exclude = [
 	# .vscode/
 	# requests are forbidden
 	"https://code.visualstudio.com",
-	# wsl/install.sh
-	# can't be accessed
-	"https://mise.jdx.dev/deb",
 	# worker/tasks/worker/deploy
 	# an example of a url with authentication
 	"https://.+@github.com//owner/repo",

--- a/win/install.ps1
+++ b/win/install.ps1
@@ -539,7 +539,7 @@ $scriptOrigin = ''
 $repoName = ''
 # might be edited by the worker to use a specific ref
 $gitRef = ''
-$wslDistribution = 'Ubuntu'
+$wslDistribution = 'Ubuntu-26.04'
 $wslUsername = $env:USERNAME
 
 Test-MinimumWindowsVersion -MinimumBuild 26100 -RequiredDisplayVersionString '24H2'

--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -107,9 +107,7 @@ fi
 
 # Enable mise completion
 if command -v mise &>/dev/null; then
-	# bash-completion 2.12 or later is required, but 2.11 is installed
-	# ref: https://cdimages.ubuntu.com/ubuntu-wsl/noble/daily-live/current/noble-wsl-amd64.manifest
-	mise_completion="$(mise completion bash --include-bash-completion-lib)"
+	mise_completion="$(mise completion bash)"
 	eval "${mise_completion}"
 fi
 

--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -34,13 +34,15 @@ install_custom_registry_packages() {
 	# shellcheck source=/dev/null
 	codename="$(source /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME}}")"
 
-	log_info "Adding mise APT repository..."
-	# ref: https://mise.jdx.dev/getting-started.html#apt
-	curl --fail-with-body --silent --show-error --location https://mise.jdx.dev/gpg-key.pub |
-		gpg --dearmor |
-		sudo tee /etc/apt/keyrings/mise-archive-keyring.gpg >/dev/null
-	echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=amd64] https://mise.jdx.dev/deb stable main" |
-		sudo tee /etc/apt/sources.list.d/mise.list >/dev/null
+	log_info "Adding mise PPA..."
+	# Remove the previous mise repository before adding the PPA. Its package
+	# versions sort after equivalent PPA builds and would otherwise stay preferred.
+	sudo rm --force \
+		/etc/apt/sources.list.d/mise.list \
+		/etc/apt/keyrings/mise-archive-keyring.gpg \
+		/etc/apt/keyrings/mise-archive-keyring.pub
+	# ref: https://mise.jdx.dev/installing-mise.html#apt
+	sudo add-apt-repository --yes --no-update ppa:jdxcode/mise
 
 	log_info "Adding Docker APT repository..."
 	# ref: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
@@ -51,7 +53,7 @@ install_custom_registry_packages() {
 
 	log_info "All repositories set up. Installing mise..."
 	sudo apt-get update
-	sudo apt-get install --yes mise
+	sudo apt-get install --yes --allow-downgrades mise
 	log_info "mise installed."
 }
 

--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -35,12 +35,6 @@ install_custom_registry_packages() {
 	codename="$(source /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME}}")"
 
 	log_info "Adding mise PPA..."
-	# Remove the previous mise repository before adding the PPA. Its package
-	# versions sort after equivalent PPA builds and would otherwise stay preferred.
-	sudo rm --force \
-		/etc/apt/sources.list.d/mise.list \
-		/etc/apt/keyrings/mise-archive-keyring.gpg \
-		/etc/apt/keyrings/mise-archive-keyring.pub
 	# ref: https://mise.jdx.dev/installing-mise.html#apt
 	sudo add-apt-repository --yes --no-update ppa:jdxcode/mise
 
@@ -53,7 +47,7 @@ install_custom_registry_packages() {
 
 	log_info "All repositories set up. Installing mise..."
 	sudo apt-get update
-	sudo apt-get install --yes --allow-downgrades mise
+	sudo apt-get install --yes mise
 	log_info "mise installed."
 }
 


### PR DESCRIPTION
## Summary

- upgrade the WSL environment from Ubuntu 24.04 LTS (Noble) to Ubuntu 26.04 LTS (Resolute)
- install and select `Ubuntu-26.04` from the Windows installer, and document it as the supported WSL release
- move installer CI to the Resolute WSL image and use its system bash-completion 2.16 library
- replace mise's direct APT repository with the official Ubuntu 26.04+ `ppa:jdxcode/mise` PPA
- remove the obsolete direct-repository link-check exclusion

This PR is based directly on the current `main` branch and is not stacked on the other mise PRs.

## Migration behavior

The Windows installer installs `Ubuntu-26.04` when it is missing and makes it the default WSL distribution. An existing Ubuntu 24.04 distribution is left intact rather than upgraded or removed destructively.

A fresh `Ubuntu-26.04` distribution needs no repository cleanup. When reusing a distro configured by the previous installer, remove the old direct mise repository manually before rerunning the installer:

```sh
sudo rm --force \
  /etc/apt/sources.list.d/mise.list \
  /etc/apt/keyrings/mise-archive-keyring.gpg \
  /etc/apt/keyrings/mise-archive-keyring.pub
```

The direct repository version can sort above the equivalent PPA build—for example, `2026.7.6` is newer to APT than `2026.7.6~resolute1`. It is safe to wait for the next PPA release. To switch the installed package immediately after removing the old repository and running the updated installer, perform the downgrade once:

```sh
sudo apt-get install --yes --allow-downgrades mise
```

`--allow-downgrades` is intentionally not used by the installer during normal runs.

## Validation

- `mise run check --lint`
- `mise x lychee -- lychee --no-progress README.md wsl/install.sh .github/workflows/ci.yml`
- `bash -n wsl/install.sh`
- verified the Resolute WSL image, `software-properties-common`, and bash-completion 2.16 availability
- GitHub CI, CodeQL, installer tests, and Sourcery review passed before the migration-cleanup follow-up

## Summary by Sourcery

Upgrade the WSL-based development environment and CI from Ubuntu 24.04 to Ubuntu 26.04 and align installer, configuration, and documentation with the new release.

New Features:
- Set Ubuntu 26.04 (Ubuntu-26.04) as the default WSL distribution installed by the Windows installer.

Enhancements:
- Switch mise installation on WSL from a direct APT repository to the official Ubuntu 26.04+ mise PPA.
- Update CI to use the Ubuntu 26.04 (Resolute) WSL image and adjust cache keys accordingly.
- Simplify bash completion setup for mise by relying on the newer system bash-completion support in the updated WSL image.
- Refresh README to document Ubuntu 26.04 LTS as the supported WSL environment.

Documentation:
- Document Ubuntu 26.04 LTS as the target WSL distribution in the README.

Tests:
- Remove the obsolete lychee exclusion for the old direct mise APT repository URL.

Chores:
- Clean up link-check configuration now that the legacy mise APT endpoint is no longer used.