### PR TITLE
refactor(installer): hardcode repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ This repository is organized around the two installer entry points:
 
 - `worker/` is a Cloudflare Worker for `dot.risunosu.com`. It redirects the root
   route to this README and serves the `/win` and `/wsl` installer routes by
-  fetching the matching scripts from GitHub and injecting repository/ref
-  metadata.
+  fetching the matching scripts from GitHub and injecting the requested Git ref
+  and script origin.
 
 - `docker/` and `compose.ci.yml` define the Ubuntu WSL-like test environment
   used by CI to exercise the WSL installer.

--- a/win/install.ps1
+++ b/win/install.ps1
@@ -535,8 +535,7 @@ function Invoke-GitSetupInWsl {
 
 # must be edited by the worker to use the same script as requested by the user
 $scriptOrigin = ''
-# must be edited by the worker to use the correct GitHub repository
-$repoName = ''
+$repoName = 'risu729/dotfiles'
 # might be edited by the worker to use a specific ref
 $gitRef = ''
 $wslDistribution = 'Ubuntu-26.04'

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -49,11 +49,6 @@ app.get("/:os{win|wsl}", async ({ req, text }) => {
 
 	const variables = [
 		{
-			name: "repo_name",
-			os: ["win", "wsl"],
-			value: import.meta.env.REPO_NAME,
-		},
-		{
 			name: "git_ref",
 			os: ["win", "wsl"],
 			value: ref ?? "",

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -3,7 +3,7 @@ import { diffLines } from "diff";
 import type { ChangeObject } from "diff";
 import { describe, expect, it } from "vitest";
 
-/* oxlint-disable eslint/max-lines-per-function eslint/max-statements jest/no-conditional-in-test jest/prefer-expect-assertions vitest/prefer-expect-assertions vitest/require-test-timeout */
+/* oxlint-disable eslint/max-lines-per-function jest/no-conditional-in-test jest/prefer-expect-assertions vitest/prefer-expect-assertions vitest/require-test-timeout */
 
 describe("worker", () => {
 	it("redirect / to repository readme", async () => {
@@ -25,22 +25,6 @@ describe("worker", () => {
 			const response = await SELF.fetch(`https://dot.risunosu.com${path}`);
 			expect(response.status).toBe(200);
 		});
-	});
-
-	describe("return the installer script with the hardcoded repo name", () => {
-		it.each(["/win", "/wsl"])(
-			"return %s with repo name",
-			{
-				// Regex matching takes time
-				timeout: 10_000,
-			},
-			async (path) => {
-				const response = await SELF.fetch(`https://dot.risunosu.com${path}`);
-				await expect(response.text()).resolves.toMatch(
-					/^.?repo(?:_n|N)ame *= *["']risu729\/dotfiles["']/gmu,
-				);
-			},
-		);
 	});
 
 	describe("return the installer script with the specified ref set", () => {

--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -27,7 +27,7 @@ describe("worker", () => {
 		});
 	});
 
-	describe("return the installer script with the specified repo name set", () => {
+	describe("return the installer script with the hardcoded repo name", () => {
 		it.each(["/win", "/wsl"])(
 			"return %s with repo name",
 			{
@@ -154,8 +154,8 @@ describe("worker", () => {
 		it.each(["/win", "/wsl"])("return %s with default branch", async (path) => {
 			const response = await SELF.fetch(`https://dot.risunosu.com${path}`);
 			const diff = await getDiffLines(response);
-			// Source URL and git ref must be different
-			expect(diff.filter((change) => change.added)).toHaveLength(path === "/win" ? 3 : 2);
+			// Source URL and script origin must be different
+			expect(diff.filter((change) => change.added)).toHaveLength(path === "/win" ? 2 : 1);
 		});
 
 		it.each(["/win", "/wsl"])("return %s with ref", async (path) => {
@@ -163,8 +163,8 @@ describe("worker", () => {
 				`https://dot.risunosu.com${path}?ref=${import.meta.env.LATEST_COMMIT_HASH}`,
 			);
 			const diff = await getDiffLines(response);
-			// Source URL, git ref, and repo name must be different
-			expect(diff.filter((change) => change.added)).toHaveLength(path === "/win" ? 4 : 3);
+			// Source URL, git ref, and script origin must be different
+			expect(diff.filter((change) => change.added)).toHaveLength(path === "/win" ? 3 : 2);
 		});
 	});
 

--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-# must be edited by the worker to use the correct GitHub repository
-repo_name=""
+repo_name="risu729/dotfiles"
 # might be edited by the worker to checkout a specific ref
 git_ref=""
 


### PR DESCRIPTION
## Summary

- hardcode `risu729/dotfiles` in the Windows and WSL installers
- stop the Worker from injecting the repository name while retaining Git ref and script-origin injection
- update Worker tests and documentation for the smaller mutation surface

## Why

This repository is fixed and personal, so making the repository name part of each installer makes the raw installer scripts directly usable and removes an unnecessary Worker-templated variable.

## Validation

- `mise run check --lint`
- `CI=true mise run worker:test` (21 tests passed)

## Summary by Sourcery

Hardcode the GitHub repository name directly in the Windows and WSL installers and simplify the Worker’s responsibility to only inject Git ref and script-origin metadata.

Enhancements:
- Remove Worker-side injection of the repository name and rely on static values in the installers to reduce template mutation surface.

Documentation:
- Clarify README to state that the Worker injects only the requested Git ref and script origin metadata into installers.

Tests:
- Remove Worker tests related to repository name injection and adjust expectations for injected metadata differences in remaining installer tests.