### PR TITLE
feat(mise): bootstrap repositories

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -128,6 +128,20 @@ fi
 "apt:xdg-utils" = "latest"
 "apt:zip" = "latest"
 
+[bootstrap.repos]
+"~/.ghr/github.com/risu729/aqua" = { url = "https://github.com/risu729/aqua.git" }
+"~/.ghr/github.com/risu729/aqua-registry" = { url = "https://github.com/risu729/aqua-registry.git" }
+"~/.ghr/github.com/risu729/biwa" = { url = "https://github.com/risu729/biwa.git" }
+"~/.ghr/github.com/risu729/hk" = { url = "https://github.com/risu729/hk.git" }
+"~/.ghr/github.com/risu729/hk-config" = { url = "https://github.com/risu729/hk-config.git" }
+"~/.ghr/github.com/risu729/kuebiko" = { url = "https://github.com/risu729/kuebiko.git" }
+"~/.ghr/github.com/risu729/mikoto" = { url = "https://github.com/risu729/mikoto.git" }
+"~/.ghr/github.com/risu729/mise" = { url = "https://github.com/risu729/mise.git" }
+"~/.ghr/github.com/risu729/mise-action" = { url = "https://github.com/risu729/mise-action.git" }
+"~/.ghr/github.com/risu729/renovate-config" = { url = "https://github.com/risu729/renovate-config.git" }
+"~/.ghr/github.com/risu729/tsconfigs" = { url = "https://github.com/risu729/tsconfigs.git" }
+"~/.ghr/github.com/risu729/unsw-cse" = { url = "https://github.com/risu729/unsw-cse.git" }
+
 [bootstrap.user]
 login_shell = "/bin/bash"
 

--- a/mise.toml
+++ b/mise.toml
@@ -140,7 +140,6 @@ fi
 "~/.ghr/github.com/risu729/mise-action" = { url = "https://github.com/risu729/mise-action.git" }
 "~/.ghr/github.com/risu729/renovate-config" = { url = "https://github.com/risu729/renovate-config.git" }
 "~/.ghr/github.com/risu729/tsconfigs" = { url = "https://github.com/risu729/tsconfigs.git" }
-"~/.ghr/github.com/risu729/unsw-cse" = { url = "https://github.com/risu729/unsw-cse.git" }
 
 [bootstrap.user]
 login_shell = "/bin/bash"


### PR DESCRIPTION
## What

- declare 11 frequently used repositories in `[bootstrap.repos]`
- clone them into the existing `~/.ghr/github.com/risu729/...` layout
- use HTTPS origins so public repositories can be restored without SSH setup

## Why

Restore the selected development repositories automatically when bootstrapping a new WSL installation instead of keeping a separate `ghr list` backup.

## Impact

`mise bootstrap` or `mise bootstrap repos apply` will clone missing repositories. Existing repositories are only accepted when their origin matches, and dirty worktrees are not overwritten. No `ref` is pinned, so existing matching repositories are not implicitly updated.

The dotfiles repository is intentionally excluded because this configuration is only available after dotfiles has already been cloned.

## Checks

- `mise bootstrap repos status --json`
- `mise run check --lint`
- verified all configured URLs match the current HTTPS origins

## Summary by Sourcery

New Features:
- Configure bootstrap.repos entries in mise.toml to automatically clone a curated list of development repositories into the ~/.ghr/github.com/risu729 directory structure.