### PR TITLE
refactor(installer): hardcode repository metadata

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -7,13 +7,12 @@ import { poweredBy } from "hono/powered-by";
 type Os = "win" | "wsl";
 
 const app: Hono = new Hono();
+const repoName = "risu729/dotfiles";
 
 app.use(poweredBy());
 
 // Redirect to the readme
-app.get("/", ({ redirect }) =>
-	redirect(`https://github.com/${import.meta.env.REPO_NAME}#readme`, 307),
-);
+app.get("/", ({ redirect }) => redirect(`https://github.com/${repoName}#readme`, 307));
 
 const shebangRegex = /^#!.*\n+/u;
 
@@ -26,13 +25,13 @@ app.get("/:os{win|wsl}", async ({ req, text }) => {
 		throw new HTTPException(500, { message: "routing error" });
 	}
 
-	const scriptUrl = `https://raw.githubusercontent.com/${import.meta.env.REPO_NAME}/${
+	const scriptUrl = `https://raw.githubusercontent.com/${repoName}/${
 		ref ?? import.meta.env.DEFAULT_BRANCH
 	}/${os}/install.${os === "win" ? "ps1" : "sh"}`;
 	// Do not cache the installer script to always fetch the latest version
 	const githubResponse = await fetch(scriptUrl, {
 		headers: {
-			"User-Agent": `${import.meta.env.REPO_NAME} worker`,
+			"User-Agent": `${repoName} worker`,
 			// Authorize with the GITHUB_TOKEN if provided to avoid rate limiting
 			...(import.meta.env.GITHUB_TOKEN
 				? {

--- a/worker/src/vite-env.d.ts
+++ b/worker/src/vite-env.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-	readonly REPO_NAME: string;
 	readonly DEFAULT_BRANCH: string;
 	readonly GITHUB_TOKEN: string | undefined;
 }

--- a/worker/vite.config.ts
+++ b/worker/vite.config.ts
@@ -1,33 +1,12 @@
-import { exec } from "node:child_process";
 import process from "node:process";
-import { promisify } from "node:util";
 
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
 
-const execAsync = promisify(exec);
-
-const { stdout: remoteInfo } = await execAsync("git remote show origin");
-// In cloudflare workers builds, the url is in the format `https://*****@github.com//owner/repo`
-// Not sure why there are two slashes, so use `+` to match one or more slashes
-const repoName: string | undefined = remoteInfo.match(
-	/Fetch URL:.*github\.com\/+(?<repo>[^/.]+\/[^/.]+)/u,
-)?.groups?.["repo"];
-if (!repoName) {
-	throw new Error("Could not determine repository name from git remote.");
-}
-const defaultBranch: string | undefined = remoteInfo.match(/HEAD branch: (?<branch>.+)/u)?.groups?.[
-	"branch"
-];
-if (!defaultBranch) {
-	throw new Error("Could not determine default branch from git remote.");
-}
-
 // Ref: https://vite.dev/config/
 export default defineConfig(({ mode }) => ({
 	define: {
-		"import.meta.env.DEFAULT_BRANCH": JSON.stringify(defaultBranch),
-		"import.meta.env.REPO_NAME": JSON.stringify(repoName),
+		"import.meta.env.DEFAULT_BRANCH": JSON.stringify("main"),
 		...(mode === "production"
 			? {}
 			: { "import.meta.env.GITHUB_TOKEN": JSON.stringify(process.env["GITHUB_TOKEN"]) }),

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -30,8 +30,6 @@ export default defineConfig({
 			GITHUB_TOKEN: process.env["GITHUB_TOKEN"],
 
 			LATEST_COMMIT_HASH: latestCommitHash,
-			// Fix constants in tests
-			REPO_NAME: "risu729/dotfiles",
 		},
 	},
 });

--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -61,18 +61,12 @@ checkout_default_git_branch() {
 }
 
 clone_or_update_dotfiles_repo() {
-	local target_repo_name="$1"
-	local target_git_ref="$2"
+	local target_git_ref="$1"
 
-	if [[ -z ${target_repo_name} ]]; then
-		log_error "Repository name not provided to clone_or_update_dotfiles_repo function."
-		exit 1
-	fi
-
-	local repo_url="github.com/${target_repo_name}"
+	local repo_url="github.com/${repo_name}"
 	local dotfiles_target_dir="${HOME}/.ghr/${repo_url}"
 
-	log_info "Preparing dotfiles repository: ${target_repo_name} in ${dotfiles_target_dir}"
+	log_info "Preparing dotfiles repository: ${repo_name} in ${dotfiles_target_dir}"
 	mkdir --parents "${dotfiles_target_dir}"
 
 	local original_dir
@@ -170,7 +164,7 @@ main() {
 	install_mise
 
 	local dotfiles_dir
-	dotfiles_dir=$(clone_or_update_dotfiles_repo "${repo_name}" "${git_ref}")
+	dotfiles_dir=$(clone_or_update_dotfiles_repo "${git_ref}")
 
 	local wsl_config_dir="${dotfiles_dir}/wsl"
 	create_etc_symlinks "${wsl_config_dir}"


### PR DESCRIPTION
## Summary

- use fixed `risu729/dotfiles` and `main` metadata in the Worker build
- remove dynamic Git remote parsing and `REPO_NAME` environment/type plumbing
- simplify the WSL clone helper now that the repository name cannot be empty

## Why

The installers and Worker are specific to this personal repository. Dynamically rediscovering fixed repository metadata adds failure paths and configuration without providing useful flexibility.

## Validation

- `mise run check --lint`
- `CI=true mise run worker:test` (21 tests passed)

## Summary by Sourcery

Hardcode repository metadata for the worker and WSL installer to target the risu729/dotfiles main branch and remove dynamic Git remote parsing.

Enhancements:
- Replace dynamic Git remote discovery in the worker build with fixed default branch and repository metadata.
- Simplify the WSL clone helper to rely on a predefined repository name instead of passing it as a parameter.
- Inline the repository name constant in the worker runtime code and remove unused REPO_NAME configuration and typing from build and test configs.