### PR TITLE
refactor(wsl): remove unused warning logger

### DIFF
--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -8,15 +8,10 @@ git_ref=""
 
 RESET='\033[0m'
 CYAN='\033[0;36m'
-YELLOW='\033[0;33m'
 RED='\033[0;31m'
 
 log_info() {
 	echo -e "${CYAN}INFO: $1${RESET}" >&2
-}
-
-log_warn() {
-	echo -e "${YELLOW}WARNING: $1${RESET}" >&2
 }
 
 log_error() {


### PR DESCRIPTION
## Summary

Remove the unused `log_warn` helper and its `YELLOW` color constant from the WSL installer.

## Why

No installer path calls the warning helper, so both declarations are dead code.

## Validation

- `mise run check --lint`

## Summary by Sourcery

Enhancements:
- Clean up dead code by deleting the unused warning logger function and its color constant from the WSL installer.