### PR TITLE
refactor(wsl): avoid redundant branch checkout

### DIFF
--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -180,7 +180,9 @@ main() {
 	mise --cd "${dotfiles_dir}" bootstrap --yes --update --force-dotfiles --locked
 	log_info "mise bootstrap completed."
 
-	checkout_default_git_branch "${dotfiles_dir}"
+	if [[ -n ${git_ref} ]]; then
+		checkout_default_git_branch "${dotfiles_dir}"
+	fi
 
 	log_info "WSL setup script finished successfully!"
 	log_info "Reminder: you might need to start a new shell for all changes to take effect."


### PR DESCRIPTION
## Summary

Only restore the repository's default branch after bootstrap when the installer temporarily checked out a requested `git_ref`.

## Why

Normal installs already switch to the default branch before bootstrap. Repeating the checkout afterward performs another remote-default lookup and checkout without changing state. Ref-based installs still return to the default branch as before.

## Validation

- `bash -n wsl/install.sh`
- `shellcheck wsl/install.sh`
- `shfmt --diff wsl/install.sh`

## Summary by Sourcery

Enhancements:
- Optimize the WSL installer flow by skipping an unnecessary default-branch checkout when no git_ref was requested.