### PR TITLE
fix(ci): preserve mise minimum version check

### DIFF
--- a/worker/docker/entrypoint.sh
+++ b/worker/docker/entrypoint.sh
@@ -52,9 +52,5 @@ echo "==> Checked out FETCH_HEAD (commit ${GIT_COMMIT_SHA})."
 
 echo "==> Successfully sparse-cloned and checked out commit ${GIT_COMMIT_SHA}."
 
-# remove min_version from mise.toml to ignore version check
-sed --in-place '/^min_version/d' mise.toml
-echo "==> Removed min_version from mise.toml."
-
 # --host required to be accessible from other containers
 exec /bin/bash -c "mise run worker:preview --host"


### PR DESCRIPTION
## Summary

Stop deleting `min_version` from `mise.toml` in the Worker test-container entrypoint.

## Root cause

CI already reads `min_version` from the same checked-out `mise.toml` and installs that mise version into the image. Removing the requirement afterward bypasses a useful consistency check and can hide an unexpectedly old image.

## Validation

- `bash -n worker/docker/entrypoint.sh`
- `shellcheck worker/docker/entrypoint.sh`
- `shfmt --diff worker/docker/entrypoint.sh`

## Summary by Sourcery

Preserve the mise minimum version check in the worker test-container entrypoint script by no longer modifying mise.toml during startup.

Bug Fixes:
- Ensure CI respects the mise min_version constraint instead of silently bypassing it in the worker test-container.

CI:
- Align the worker test-container entrypoint behavior with CI by keeping mise.toml intact so version checks remain enforced.