### PR TITLE
test(worker): remove redundant ref status tests

### DIFF
--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -75,15 +75,6 @@ describe("worker", () => {
 		);
 	});
 
-	describe("return 200 status code with ref query parameters", () => {
-		it.each(["/win", "/wsl"])("return %s with ref", async (path) => {
-			const response = await SELF.fetch(
-				`https://dot.risunosu.com${path}?ref=${import.meta.env.LATEST_COMMIT_HASH}`,
-			);
-			expect(response.status).toBe(200);
-		});
-	});
-
 	it(
 		"installer script for wsl must have a shebang",
 		{


### PR DESCRIPTION
## Summary

Remove the separate `/win` and `/wsl` 200-status cases for requests with a `ref` query.

## Why

The existing ref-injection tests make the same requests and verify the returned installer content. A non-200 response cannot satisfy those assertions, so the status-only cases duplicate coverage.

## Validation

- `oxfmt --check worker/test/index.test.ts`
- `oxlint --deny-warnings --report-unused-disable-directives-severity error worker/test/index.test.ts`
- `CI=true mise run worker:test` (19 tests passed)

## Summary by Sourcery

Tests:
- Delete duplicate /win and /wsl ref query status tests that are already covered by existing ref-injection installer tests.