### PR TITLE
test(worker): combine redirect assertions

### DIFF
--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -6,17 +6,11 @@ import { describe, expect, it } from "vitest";
 /* oxlint-disable eslint/max-lines-per-function jest/no-conditional-in-test jest/prefer-expect-assertions vitest/prefer-expect-assertions vitest/require-test-timeout */
 
 describe("worker", () => {
-	it("redirect / to repository readme", async () => {
+	it("redirect / to repository readme with 307 status code", async () => {
 		const response = await SELF.fetch("https://dot.risunosu.com/", {
 			redirect: "manual",
 		});
 		expect(response.headers.get("location")).toBe("https://github.com/risu729/dotfiles#readme");
-	});
-
-	it("redirect / with 307 status code", async () => {
-		const response = await SELF.fetch("https://dot.risunosu.com/", {
-			redirect: "manual",
-		});
 		expect(response.status).toBe(307);
 	});
 


### PR DESCRIPTION
## Summary

Verify the root redirect destination and 307 status from one Worker request.

## Why

The two tests requested the same route with identical options and split assertions on the same response behavior.

## Validation

- `oxfmt --check worker/test/index.test.ts`
- `oxlint --deny-warnings --report-unused-disable-directives-severity error worker/test/index.test.ts`
- `CI=true mise run worker:test` (20 tests passed)

## Summary by Sourcery

Tests:
- Merge two worker redirect tests into one that verifies both the README redirect location and 307 status for the root URL.