### PR TITLE
test(worker): simplify script origin cases

### DIFF
--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -46,28 +46,28 @@ describe("worker", () => {
 	});
 
 	describe("return the installer script with the script origin set", () => {
-		it.each(["/win"])(
-			"return %s with script origin",
+		it(
+			"return /win with script origin",
 			{
 				// Regex matching takes time
 				timeout: 10_000,
 			},
-			async (path) => {
-				const response = await SELF.fetch(`https://dot.risunosu.com${path}`);
+			async () => {
+				const response = await SELF.fetch("https://dot.risunosu.com/win");
 				await expect(response.text()).resolves.toMatch(
 					/^.?script(?:_o|O)rigin *= *["']https:\/\/dot\.risunosu\.com["']/gmu,
 				);
 			},
 		);
 
-		it.each(["/win"])(
-			"return %s with script origin with port",
+		it(
+			"return /win with script origin with port",
 			{
 				// Regex matching takes time
 				timeout: 10_000,
 			},
-			async (path) => {
-				const response = await SELF.fetch(`http://localhost:8080${path}`);
+			async () => {
+				const response = await SELF.fetch("http://localhost:8080/win");
 				await expect(response.text()).resolves.toMatch(
 					/^.?script(?:_o|O)rigin *= *["']http:\/\/localhost:8080["']/gmu,
 				);


### PR DESCRIPTION
## Summary

Replace single-element `it.each(["/win"])` cases with direct tests and explicit `/win` URLs.

## Why

These script-origin scenarios only support Windows, so one-element parameterization adds indirection without exercising another case.

## Validation

- `oxfmt --check worker/test/index.test.ts`
- `oxlint --deny-warnings --report-unused-disable-directives-severity error worker/test/index.test.ts`
- `CI=true mise run worker:test` (21 tests passed)

## Summary by Sourcery

Enhancements:
- Remove unnecessary parameterization from worker script-origin tests to make the intent clearer.