### PR TITLE
refactor(wsl): avoid temporary etc path file

### DIFF
--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -138,14 +138,12 @@ create_etc_symlinks() {
 	log_info "Creating symbolic links for etc directory files from ${wsl_etc_config_dir}..."
 	local wsl_etc_config_relative_dir
 	wsl_etc_config_relative_dir="$(realpath --relative-to="${repo_root}" "${wsl_etc_config_dir}")"
-	local etc_paths_file
-	etc_paths_file="$(mktemp)"
-	git -C "${repo_root}" ls-files -z -- "${wsl_etc_config_relative_dir}" >"${etc_paths_file}"
 	local etc_paths=()
+	# A git failure leaves the array empty and is handled below.
+	# shellcheck disable=SC2312
 	while IFS= read -r -d '' path; do
 		etc_paths+=("${repo_root}/${path}")
-	done <"${etc_paths_file}"
-	rm -- "${etc_paths_file}"
+	done < <(git -C "${repo_root}" ls-files -z -- "${wsl_etc_config_relative_dir}")
 
 	if ((${#etc_paths[@]} == 0)); then
 		log_error "No etc directory files found to symlink."


### PR DESCRIPTION
## Summary

Feed tracked `/etc` paths directly into the installer loop with process substitution instead of creating, reading, and deleting a temporary file.

## Why

The temporary file only bridged `git ls-files` to the loop. An empty result—including a failed listing—continues to use the existing explicit no-files error path.

## Validation

- `bash -n wsl/install.sh`
- `shellcheck wsl/install.sh`
- `shfmt --diff wsl/install.sh`

## Summary by Sourcery

Enhancements:
- Simplify etc symlink creation by replacing the temporary paths file with direct process substitution from git ls-files, while preserving existing empty-result handling.