### PR TITLE
fix(shell): guard pitchfork activation correctly

### DIFF
--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -100,7 +100,7 @@ if command -v zoxide &>/dev/null; then
 fi
 
 # Activate pitchfork
-if command -v mise &>/dev/null; then
+if command -v pitchfork &>/dev/null; then
 	mise_activate="$(pitchfork activate bash)"
 	eval "${mise_activate}"
 fi

--- a/wsl/home/.bashrc
+++ b/wsl/home/.bashrc
@@ -101,8 +101,8 @@ fi
 
 # Activate pitchfork
 if command -v pitchfork &>/dev/null; then
-	mise_activate="$(pitchfork activate bash)"
-	eval "${mise_activate}"
+	pitchfork_activate="$(pitchfork activate bash)"
+	eval "${pitchfork_activate}"
 fi
 
 # Enable mise completion


### PR DESCRIPTION
## Summary

Check that `pitchfork` exists before invoking `pitchfork activate bash`.

## Root cause

The activation block checked for `mise` instead. A shell with mise installed but pitchfork unavailable would still attempt to execute the missing command.

## Validation

- `bash -n wsl/home/.bashrc`
- `shellcheck --shell bash wsl/home/.bashrc`
- `shfmt --diff wsl/home/.bashrc`

## Summary by Sourcery

Bug Fixes:
- Prevent attempting to run pitchfork activation when pitchfork is not installed by checking for the correct command before evaluating the activation snippet.