### PR TITLE
test(worker): reuse default branch test ref

### DIFF
--- a/worker/test/index.test.ts
+++ b/worker/test/index.test.ts
@@ -30,10 +30,10 @@ describe("worker", () => {
 			},
 			async (path) => {
 				const response = await SELF.fetch(
-					`https://dot.risunosu.com${path}?ref=${import.meta.env.LATEST_COMMIT_HASH}`,
+					`https://dot.risunosu.com${path}?ref=${import.meta.env.DEFAULT_BRANCH}`,
 				);
 				await expect(response.text()).resolves.toMatch(
-					new RegExp(`^.?git(?:_r|R)ef *= *["']${import.meta.env.LATEST_COMMIT_HASH}["']`, "gmu"),
+					new RegExp(`^.?git(?:_r|R)ef *= *["']${import.meta.env.DEFAULT_BRANCH}["']`, "gmu"),
 				);
 			},
 		);
@@ -93,12 +93,12 @@ describe("worker", () => {
 
 		it.each(["/win", "/wsl"])("return %s with ref", async (path) => {
 			const response = await SELF.fetch(
-				`https://dot.risunosu.com${path}?ref=${import.meta.env.LATEST_COMMIT_HASH}`,
+				`https://dot.risunosu.com${path}?ref=${import.meta.env.DEFAULT_BRANCH}`,
 			);
 			const script = await response.text();
 			const sourceUrl = [...script.matchAll(/# source: (?<url>.+)/gu)].at(0)?.groups?.["url"];
 			expect(sourceUrl).toBe(
-				`https://raw.githubusercontent.com/risu729/dotfiles/${import.meta.env.LATEST_COMMIT_HASH}${path}/install.${
+				`https://raw.githubusercontent.com/risu729/dotfiles/${import.meta.env.DEFAULT_BRANCH}${path}/install.${
 					path === "/win" ? "ps1" : "sh"
 				}`,
 			);
@@ -129,7 +129,7 @@ describe("worker", () => {
 
 		it.each(["/win", "/wsl"])("return %s with ref", async (path) => {
 			const response = await SELF.fetch(
-				`https://dot.risunosu.com${path}?ref=${import.meta.env.LATEST_COMMIT_HASH}`,
+				`https://dot.risunosu.com${path}?ref=${import.meta.env.DEFAULT_BRANCH}`,
 			);
 			const diff = await getDiffLines(response);
 			// Source URL, git ref, and script origin must be different

--- a/worker/test/vite-env.d.ts
+++ b/worker/test/vite-env.d.ts
@@ -2,7 +2,6 @@
 
 interface ImportMetaEnv {
 	readonly DEFAULT_BRANCH: string;
-	readonly LATEST_COMMIT_HASH: string;
 }
 
 interface ImportMeta {

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -28,8 +28,6 @@ export default defineConfig({
 
 			// Define in vite.config.ts does not work in vitest, so define here
 			GITHUB_TOKEN: process.env["GITHUB_TOKEN"],
-
-			LATEST_COMMIT_HASH: latestCommitHash,
 		},
 	},
 });


### PR DESCRIPTION
## Summary

- use `DEFAULT_BRANCH` as the pinned commit for both default-branch and explicit-ref worker tests
- remove the duplicate `LATEST_COMMIT_HASH` Vitest environment variable and type

## Validation

- `mise run check --lint`
- `CI=true mise run worker:test` (18 tests passed; one earlier network-backed fetch timed out, then passed on rerun)

## Summary by Sourcery

Consolidate worker tests to use the default branch ref rather than a separate latest-commit hash value.

Build:
- Remove the LATEST_COMMIT_HASH Vitest runtime environment variable and its associated type definition from the worker test configuration.

Tests:
- Update worker integration tests to use DEFAULT_BRANCH as the ref for fetch URLs and expectations instead of a dedicated latest-commit hash env var.