### PR TITLE
refactor(worker): simplify deploy metadata

### DIFF
--- a/worker/tasks/worker/deploy
+++ b/worker/tasks/worker/deploy
@@ -26,10 +26,9 @@ fi
 
 # tag length is limited to 25 characters
 short_sha=$(git rev-parse --short HEAD)
-message=$(git log --format=%B --max-count=1 "${short_sha}" | head --lines=1 | sed 's/"/\\"/g')
+message=$(git log -1 --format=%s HEAD)
 
 set -x
-# shellcheck disable=SC2086 # avoid quoting wrangler_cmd and vars
 bun run wrangler versions upload --tag "${short_sha}" --message "${message}"
 set +x
 


### PR DESCRIPTION
## Summary

- read the deployment message directly from the current commit subject
- preserve quotes in commit subjects instead of escaping them before passing a quoted argument
- remove a stale ShellCheck suppression that no longer applies

## Validation

- `bash -n worker/tasks/worker/deploy`
- `mise exec -- shellcheck worker/tasks/worker/deploy`
- `mise exec -- shfmt --diff worker/tasks/worker/deploy`
- `mise run check --lint`

## Summary by Sourcery

Simplify how worker deploy metadata is derived from git commits while cleaning up the deploy script.

Enhancements:
- Read the deployment message directly from the current commit subject instead of a separate metadata source.
- Preserve quotes in commit subjects when passing them as arguments in the deploy script to avoid unnecessary escaping.
- Remove an obsolete ShellCheck suppression from the worker deploy script that is no longer needed.

Tests:
- Run shell syntax checks, linting, and formatting tools against the worker deploy script to validate the changes.