### PR TITLE
refactor(worker): simplify preview container

### DIFF
--- a/worker/docker/Dockerfile
+++ b/worker/docker/Dockerfile
@@ -12,14 +12,12 @@ RUN apt-get update && \
 
 # Configure mise environment variables
 # ref: https://mise.jdx.dev/mise-cookbook/docker.html
-ENV ROOT_DIR="/dotfiles"
 ENV MISE_DATA_DIR="/mise"
 ENV MISE_CACHE_DIR="/mise/cache"
 ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
-ENV MISE_TRUSTED_CONFIG_PATHS=${ROOT_DIR}
+ENV MISE_TRUSTED_CONFIG_PATHS="/dotfiles"
 ENV MISE_ENABLE_TOOLS=bun,node
 ENV MISE_YES=1
-ENV MISE_VERSION=${MISE_VERSION}
 ENV PATH="${MISE_DATA_DIR}/shims:${MISE_INSTALL_PATH%/*}:$PATH"
 
 # Install mise with GPG verification and specific version
@@ -39,7 +37,8 @@ RUN set -eux && \
     git config --global init.defaultBranch main && \
     git config --global advice.detachedHead false
 
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+WORKDIR /dotfiles
+
+COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/worker/docker/entrypoint.sh
+++ b/worker/docker/entrypoint.sh
@@ -2,14 +2,8 @@
 set -euo pipefail
 
 # Environment Variables:
-# ROOT_DIR: Directory to clone the repository into
 # GIT_REPO_URL: URL of the repository to clone
 # GIT_COMMIT_SHA: Exact commit SHA to checkout
-
-if [[ -z ${ROOT_DIR:-} ]]; then
-	echo "Error: ROOT_DIR environment variable is not set."
-	exit 1
-fi
 
 if [[ -z ${GIT_REPO_URL:-} ]]; then
 	echo "Error: GIT_REPO_URL environment variable is not set."
@@ -22,10 +16,6 @@ if [[ -z ${GIT_COMMIT_SHA:-} ]]; then
 fi
 
 echo "==> Preparing to clone repository ${GIT_REPO_URL} at commit ${GIT_COMMIT_SHA}"
-echo "==> Target directory for repository root: ${ROOT_DIR}"
-
-mkdir -p "${ROOT_DIR}"
-cd "${ROOT_DIR}"
 
 git init .
 echo "==> Initialized git repository."
@@ -53,4 +43,4 @@ echo "==> Checked out FETCH_HEAD (commit ${GIT_COMMIT_SHA})."
 echo "==> Successfully sparse-cloned and checked out commit ${GIT_COMMIT_SHA}."
 
 # --host required to be accessible from other containers
-exec /bin/bash -c "mise run worker:preview --host"
+exec mise run worker:preview --host


### PR DESCRIPTION
## Summary

- use the image workdir for the fixed `/dotfiles` checkout path instead of a configurable `ROOT_DIR`
- keep `MISE_VERSION` as a build argument without redundantly persisting it in the image environment
- set entrypoint permissions while copying the file
- execute `mise` directly without an extra Bash process

## Validation

- `bash -n worker/docker/entrypoint.sh`
- `mise exec -- shellcheck worker/docker/entrypoint.sh`
- `mise exec -- shfmt --diff worker/docker/entrypoint.sh`
- `docker compose --file compose.ci.yml config --quiet`
- `docker build --check --build-arg MISE_VERSION=2026.7.7 worker/docker`
- `mise run check --lint`

## Summary by Sourcery

Simplify the worker preview container setup and entrypoint execution.

Enhancements:
- Rely on the image workdir (/dotfiles) instead of a configurable ROOT_DIR for cloning the repository.
- Avoid persisting MISE_VERSION in the image environment while keeping it as a build argument.
- Set the container workdir to /dotfiles and update mise trusted config paths accordingly.
- Copy the entrypoint script with executable permissions in a single Dockerfile step.
- Execute the preview task via mise directly from the entrypoint without spawning an extra Bash process.