### PR TITLE
refactor(wsl): simplify repository checkout

### DIFF
--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -42,7 +42,6 @@ checkout_default_git_branch() {
 	git_remote=$(git remote show origin 2>/dev/null)
 	local default_branch
 	default_branch=$(echo "${git_remote}" | grep --only-matching --perl-regexp 'HEAD branch: \K.+')
-	default_branch=$(echo "${default_branch}" | tr --delete '\n')
 
 	if [[ -z ${default_branch} ]]; then
 		log_error "Could not determine the default branch for '${repo_path}'."
@@ -97,7 +96,7 @@ clone_or_update_dotfiles_repo() {
 		fi
 	else
 		log_info "Cloning repository https://${repo_url}.git into ${dotfiles_target_dir}..."
-		git clone --origin origin "https://${repo_url}.git" "${dotfiles_target_dir}" >&2
+		git clone "https://${repo_url}.git" "${dotfiles_target_dir}" >&2
 	fi
 
 	# Checkout a specific ref if specified
@@ -108,8 +107,7 @@ clone_or_update_dotfiles_repo() {
 	else
 		# If not checking out a specific ref, ensure we are on the default branch
 		# and that it's up-to-date (which pull/fetch should have handled).
-		# The checkout_default_git_branch might be redundant if pull/fetch worked,
-		# but it ensures the correct branch is checked out if it wasn't already.
+		# An existing repository may have had a different branch checked out.
 		checkout_default_git_branch "${dotfiles_target_dir}" >&2
 	fi
 


### PR DESCRIPTION
## Summary

- rely on command substitution to strip the default branch output newline
- rely on Git’s default `origin` remote name when cloning
- clarify why an existing checkout still needs to switch to the default branch

## Validation

- `bash -n wsl/install.sh`
- `mise exec -- shellcheck wsl/install.sh`
- `mise exec -- shfmt --diff wsl/install.sh`
- `mise run check --lint`

## Summary by Sourcery

Simplify the WSL dotfiles repository checkout logic and rely more on Git defaults.

Enhancements:
- Rely on command substitution to obtain the default Git branch name without manual newline stripping.
- Use Git’s default remote naming when cloning the dotfiles repository instead of explicitly specifying the origin name.
- Clarify the rationale for checking out the default branch when reusing an existing repository checkout.