### PR TITLE
refactor(worker): hardcode repository URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           __CI: true
-          GIT_REPO_URL: ${{ github.event.repository.clone_url }}
           # use head sha for pull requests because github.sha is set to the merge commit
           GIT_COMMIT_SHA: ${{ case(github.event_name == 'pull_request', github.event.pull_request.head.sha, github.sha) }}
           MISE_LOG_LEVEL: ${{ case(runner.debug == '1', 'debug', 'info') }}

--- a/compose.ci.yml
+++ b/compose.ci.yml
@@ -6,7 +6,6 @@ services:
       args:
         MISE_VERSION: ${MISE_VERSION:-}
     environment:
-      GIT_REPO_URL: ${GIT_REPO_URL:-}
       GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     healthcheck:

--- a/worker/docker/entrypoint.sh
+++ b/worker/docker/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-repo_url="https://github.com/risu729/dotfiles.git"
+readonly repo_url="https://github.com/risu729/dotfiles.git"
 
 # Environment Variables:
 # GIT_COMMIT_SHA: Exact commit SHA to checkout

--- a/worker/docker/entrypoint.sh
+++ b/worker/docker/entrypoint.sh
@@ -1,27 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
-# Environment Variables:
-# GIT_REPO_URL: URL of the repository to clone
-# GIT_COMMIT_SHA: Exact commit SHA to checkout
+repo_url="https://github.com/risu729/dotfiles.git"
 
-if [[ -z ${GIT_REPO_URL:-} ]]; then
-	echo "Error: GIT_REPO_URL environment variable is not set."
-	exit 1
-fi
+# Environment Variables:
+# GIT_COMMIT_SHA: Exact commit SHA to checkout
 
 if [[ -z ${GIT_COMMIT_SHA:-} ]]; then
 	echo "Error: GIT_COMMIT_SHA environment variable is not set."
 	exit 1
 fi
 
-echo "==> Preparing to clone repository ${GIT_REPO_URL} at commit ${GIT_COMMIT_SHA}"
+echo "==> Preparing to clone repository ${repo_url} at commit ${GIT_COMMIT_SHA}"
 
 git init .
 echo "==> Initialized git repository."
 
-git remote add origin "${GIT_REPO_URL}"
-echo "==> Added remote 'origin' for ${GIT_REPO_URL}"
+git remote add origin "${repo_url}"
+echo "==> Added remote 'origin' for ${repo_url}"
 
 git sparse-checkout init
 echo "==> Initialized sparse-checkout."


### PR DESCRIPTION
## Summary

- keep the worker preview repository URL in the entrypoint that consumes it
- remove the fixed URL from the GitHub Actions and Docker Compose environment plumbing
- retain the commit SHA as input so each CI run still tests its exact revision

## Validation

- `bash -n worker/docker/entrypoint.sh`
- `mise exec -- shellcheck worker/docker/entrypoint.sh`
- `mise exec -- shfmt --diff worker/docker/entrypoint.sh`
- `docker compose --file compose.ci.yml config --quiet`
- `mise run check --lint`

## Summary by Sourcery

Hardcode the worker preview repository URL in the entrypoint script and simplify CI/Docker Compose configuration to only pass the commit SHA.

Enhancements:
- Configure the worker entrypoint to always clone a fixed dotfiles repository URL instead of reading it from environment.

CI:
- Remove GIT_REPO_URL from the CI workflow environment, relying solely on the commit SHA to identify revisions.

Deployment:
- Remove propagation of GIT_REPO_URL through the Docker Compose CI service environment, keeping only the commit SHA.