### PR TITLE
fix(mise): use valid interactive Bash flag

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -97,7 +97,7 @@ ln --symbolic --no-dereference --force \
 [bootstrap.hooks.final]
 run = '''
 if [ -t 0 ] && [ -t 1 ]; then
-  if ! mise exec -- bash --interactive -c "${MISE_PROJECT_ROOT}/wsl/setup-git.ts"; then
+  if ! mise exec -- bash -i -c "${MISE_PROJECT_ROOT}/wsl/setup-git.ts"; then
     echo "Git setup failed; run wsl/setup-git.ts manually if needed." >&2
   fi
 fi


### PR DESCRIPTION
## Summary

- invoke Bash interactive mode with the supported `-i` option
- preserve the existing best-effort Git setup behavior

## Verification

- `mise exec -- bash -i -c 'exit 0'`
- `mise x -- hk check --all`

## Summary by Sourcery

Bug Fixes:
- Use Bash’s standard -i flag for interactive mode in the bootstrap final hook to ensure compatibility with supported Bash options.