### PR TITLE
fix(mise): resolve bootstrap paths from Git root

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -90,14 +90,16 @@ sudo update-desktop-database
 [bootstrap.hooks.post-tools]
 run = '''
 # Installing this before the tools phase makes Git use gh before gh is installed.
+dotfiles_root=$(git rev-parse --show-toplevel)
 ln --symbolic --no-dereference --force \
-  "${MISE_PROJECT_ROOT}/wsl/home/.gitconfig" "${HOME}/.gitconfig"
+  "${dotfiles_root}/wsl/home/.gitconfig" "${HOME}/.gitconfig"
 '''
 
 [bootstrap.hooks.final]
 run = '''
 if [ -t 0 ] && [ -t 1 ]; then
-  if ! mise exec -- bash -i -c "${MISE_PROJECT_ROOT}/wsl/setup-git.ts"; then
+  dotfiles_root=$(git rev-parse --show-toplevel)
+  if ! mise exec -- bash -i -c "${dotfiles_root}/wsl/setup-git.ts"; then
     echo "Git setup failed; run wsl/setup-git.ts manually if needed." >&2
   fi
 fi


### PR DESCRIPTION
## Summary

- resolve the dotfiles repository root locally in each bootstrap hook with `git rev-parse --show-toplevel`
- use that root for both the Git config symlink and final Git setup command
- avoid defining or depending on a global `MISE_PROJECT_ROOT` value

## Verification

- executed the post-tools hook from `wsl/` against a temporary home and verified the symlink target
- verified the final-hook setup script path resolves from `wsl/`
- `mise x -- hk check --all`

## Summary by Sourcery

Enhancements:
- Determine the dotfiles repository root in each bootstrap hook via git rev-parse and use it for Git config symlink creation and Git setup script execution.