### PR TITLE
refactor(mise): remove obsolete GPG setup

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -82,8 +82,6 @@ fi
 
 [bootstrap.hooks.post-dotfiles]
 run = '''
-mkdir --parents "${HOME}/.gnupg"
-chmod 700 "${HOME}/.gnupg"
 sudo update-desktop-database
 '''
 


### PR DESCRIPTION
## Summary

- stop creating `~/.gnupg` during WSL bootstrap
- keep the unrelated desktop database update in place

## Verification

- verified the post-dotfiles hook no longer references `.gnupg`
- `mise x -- hk check --all`

## Summary by Sourcery

Enhancements:
- Simplify WSL bootstrap by no longer creating and configuring the ~/.gnupg directory.