### PR TITLE
fix(wsl): clean up authentication bootstrap

### DIFF
--- a/wsl/setup-git.ts
+++ b/wsl/setup-git.ts
@@ -63,25 +63,36 @@ const ensureGitHubTokenScopes = async (): Promise<void> => {
 	const requiredScopes = [
 		// Not included in the scopes granted by default in gh auth login
 		"workflow",
-		// Allow read-only access
 		"read:packages",
-		"read:project",
+		"project",
 	];
 
 	// Login to GitHub if not authenticated
-	const { stdout, exitCode } = await $`gh auth status`.env(envWithoutGitHubToken).quiet().nothrow();
+	const { stdout, exitCode } = await $`gh auth status --active --hostname github.com --json hosts`
+		.env(envWithoutGitHubToken)
+		.quiet()
+		.nothrow();
 	if (exitCode !== 0) {
 		await authWithBrowser(`login --web --git-protocol https --scopes ${requiredScopes.join(",")}`);
 		return;
 	}
+	const authStatus = JSON.parse(stdout.toString()) as {
+		hosts?: Record<
+			string,
+			{
+				active: boolean;
+				scopes: string;
+				state: string;
+			}[]
+		>;
+	};
+	const activeAccount = authStatus.hosts?.["github.com"]?.find(({ active }) => active);
+	if (activeAccount?.state !== "success") {
+		await authWithBrowser(`login --web --git-protocol https --scopes ${requiredScopes.join(",")}`);
+		return;
+	}
 
-	const scopes =
-		stdout
-			.toString()
-			.match(/Token scopes:(?<scopes>.*)/u)
-			?.groups?.["scopes"]?.trim()
-			.split(", ")
-			.map((scope) => scope.replaceAll(/'/gu, "")) ?? [];
+	const scopes = activeAccount.scopes.split(", ");
 	const missingScopes = requiredScopes.filter((scope) => !scopes.includes(scope));
 	if (missingScopes.length > 0) {
 		console.info(


### PR DESCRIPTION
## Summary

- require the `project` OAuth scope instead of `read:project`
- read the active GitHub account and scopes from `gh auth status --json hosts`
- treat a missing or unsuccessful active account as unauthenticated without revoking existing credentials

## Verification

- `mise exec -- wsl/setup-git.ts`
- `mise x -- hk check --all`

## Summary by Sourcery

Improve GitHub authentication bootstrap for WSL setup by aligning required OAuth scopes and using structured auth status output to determine active account scopes.

Bug Fixes:
- Handle missing or unsuccessful active GitHub accounts as unauthenticated without revoking existing credentials.

Enhancements:
- Update required GitHub OAuth scopes to use the broader project scope instead of read:project.
- Derive active GitHub account scopes from gh auth status JSON output for more reliable scope detection.