### PR TITLE
refactor(wsl): remove obsolete GPG configuration

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -149,7 +149,6 @@ login_shell = "/bin/bash"
 "~/.codex" = { source = "wsl/home/.codex", mode = "symlink-each" }
 "~/.config" = { source = "wsl/home/.config", mode = "symlink-each" }
 "~/.ghr" = { source = "wsl/home/.ghr", mode = "symlink-each" }
-"~/.gnupg" = { source = "wsl/home/.gnupg", mode = "symlink-each" }
 "~/.hushlogin" = "wsl/home/.hushlogin"
 "~/.local" = { source = "wsl/home/.local", mode = "symlink-each" }
 "~/.selected_editor" = "wsl/home/.selected_editor"

--- a/wsl/home/.gnupg/gpg-agent.conf
+++ b/wsl/home/.gnupg/gpg-agent.conf
@@ -1,3 +1,0 @@
-# set cache ttl to 1 week to avoid repeated password prompts
-default-cache-ttl 604800
-max-cache-ttl 604800


### PR DESCRIPTION
## Summary

- stop deploying the obsolete `~/.gnupg` dotfile directory
- remove the tracked `gpg-agent.conf` cache configuration now that Git signing uses SSH

## Verification

- `mise x -- hk check --all`

## Summary by Sourcery

Remove obsolete WSL GPG dotfile configuration from the home directory setup.

Enhancements:
- Stop deploying the ~/.gnupg directory via mise WSL home dotfiles configuration.

Chores:
- Delete the tracked gpg-agent.conf configuration file now that Git signing uses SSH.