### PR TITLE
fix(win): create WSL user without password

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ This repository is organized around the two installer entry points:
   - `wsl/home/` mirrors the target home directory. Mise links these files into
     `$HOME`, except for Codex skills, which are copied because Codex does not
     discover symlinked skill files.
-  - `wsl/etc/` mirrors root-owned system files. The installer links these files
-    into `/etc`.
   - `wsl/setup-git.ts` performs interactive GitHub authentication after the
     base WSL environment is ready. Git identity, SSH signing, and `ghr`
     defaults live in `wsl/home/.gitconfig` and `wsl/home/.ghr/ghr.toml`.

--- a/mise.toml
+++ b/mise.toml
@@ -59,6 +59,15 @@ includes = ["tasks.toml", "tasks", "worker/tasks.toml", "worker/tasks"]
 
 [bootstrap.hooks.pre-packages]
 run = '''
+# Persist passwordless sudo and replace the legacy repository symlink if present.
+sudo mkdir --parents /etc/sudoers.d
+sudoers_path=/etc/sudoers.d/01-users-nopasswd
+sudoers_temporary_path=/etc/sudoers.d/.01-users-nopasswd.tmp
+printf '%s\n' 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' |
+  sudo tee "${sudoers_temporary_path}" >/dev/null
+sudo chmod 0440 "${sudoers_temporary_path}"
+sudo mv --force "${sudoers_temporary_path}" "${sudoers_path}"
+
 sudo install --directory --mode=0755 /etc/apt/keyrings
 
 arch=$(dpkg --print-architecture)

--- a/win/install.ps1
+++ b/win/install.ps1
@@ -262,52 +262,7 @@ function Test-WslDistributionInstalled {
 
 <#
 	.SYNOPSIS
-	Prompts the user for a password and confirms it.
-
-	.OUTPUTS
-	Returns the confirmed password as a plain text string.
-#>
-function Read-Password {
-	[CmdletBinding()]
-	[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-		'PSAvoidUsingWriteHost',
-		'',
-		Justification = 'Required to prompt user'
-	)]
-	param()
-
-	while ($true) {
-		Write-Host 'Enter password:'
-		# Use -AsSecureString to mask input
-		$passwordSecure = Read-Host -AsSecureString
-		$password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto(
-			[System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($passwordSecure)
-		)
-
-		if ($null -eq $password -or [string]::IsNullOrEmpty($password)) {
-			Write-Warning 'Password cannot be empty. Try again.'
-			continue
-		}
-
-		Write-Host 'Re-enter password:'
-		$confirmPasswordSecure = Read-Host -AsSecureString
-		$confirmPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto(
-			[System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($confirmPasswordSecure)
-		)
-
-		# if doesn't match, prompt again
-		if ($password -ne $confirmPassword) {
-			Write-Warning 'Passwords do not match. Try again.'
-			continue
-		}
-
-		return $password
-	}
-}
-
-<#
-	.SYNOPSIS
-	Creates a new user in the WSL distribution.
+	Creates a new user with a locked password in the WSL distribution.
 #>
 function New-WslUser {
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
@@ -316,16 +271,6 @@ function New-WslUser {
 		Justification = 'No confirmation needed for this script'
 	)]
 	[CmdletBinding()]
-	[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-		'PSAvoidUsingPlainTextForPassword',
-		'',
-		Justification = 'chpasswd requires plain text password'
-	)]
-	[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-		'PSAvoidUsingUsernameAndPasswordParams',
-		'',
-		Justification = 'chpasswd requires plain text password'
-	)]
 	param(
 		[Parameter(Mandatory = $true)]
 		# The name of the WSL distribution to create the user in.
@@ -333,19 +278,25 @@ function New-WslUser {
 
 		[Parameter(Mandatory = $true)]
 		# The username for the new WSL user.
-		[string]$Username,
-
-		[Parameter(Mandatory = $true)]
-		# The plain text password for the new user.
-		[string]$Password
+		[string]$Username
 	)
 
 	# No need to check the duplicate username because useradd will fail if it exists
+	# Omitting --password leaves password authentication locked.
 	Invoke-WSLCommand -Root -Command "useradd --create-home $Username"
-	Invoke-WSLCommand -Root -Command "echo ${Username}:$Password | chpasswd"
 	Invoke-WSLCommand -Root -Command "usermod --append --groups sudo $Username"
 
-	Write-Information "User '$Username' created in WSL distribution '$Distribution'."
+	# The WSL setup script needs sudo before it can link the managed sudoers file.
+	$sudoersPath = '/etc/sudoers.d/01-users-nopasswd'
+	Invoke-WSLCommand -Root -Command 'install --directory --mode=0755 /etc/sudoers.d'
+	Invoke-WSLCommand -Root -Command (
+		"printf '%s\n' 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' > $sudoersPath && " +
+		"chmod 0440 $sudoersPath"
+	)
+
+	Write-Information (
+		"User '$Username' created with a locked password in WSL distribution '$Distribution'."
+	)
 }
 
 <#
@@ -364,10 +315,6 @@ function Install-Wsl {
 <#
 	.SYNOPSIS
 	Sets up the WSL distribution.
-
-	.NOTES
-	Requires user interaction for password input.
-	Fails if the distribution is already installed.
 #>
 function Install-WslDistribution {
 	[CmdletBinding()]
@@ -396,8 +343,7 @@ function Install-WslDistribution {
 	if (-not $isDistributionInstalled) {
 		# no-launch skips user creation, so we need to create it manually
 		# ref: https://github.com/microsoft/WSL/issues/10386
-		$password = Read-Password
-		New-WslUser -Distribution $Distribution -Username $Username -Password $password
+		New-WslUser -Distribution $Distribution -Username $Username
 		# Set the default user to the created user
 		Invoke-ExternalCommand "wsl --manage `"$Distribution`" --set-default-user `"$Username`""
 	}

--- a/win/install.ps1
+++ b/win/install.ps1
@@ -317,7 +317,7 @@ function New-WslUser {
 		-FilePath '/usr/sbin/usermod' `
 		-ArgumentList @('--append', '--groups', 'sudo', '--', $Username)
 
-	# The WSL setup script needs sudo before it can link the managed sudoers file.
+	# The WSL setup script needs sudo before mise can persist the sudoers policy.
 	$sudoersPath = '/etc/sudoers.d/01-users-nopasswd'
 	Invoke-WSLExecutable -Root -FilePath '/usr/bin/mkdir' -ArgumentList @('--parents', '/etc/sudoers.d')
 	Invoke-WSLCommand -Root -Command (

--- a/win/install.ps1
+++ b/win/install.ps1
@@ -162,6 +162,46 @@ function Invoke-ExternalCommand {
 
 <#
 	.SYNOPSIS
+	Runs an executable in WSL without shell parsing and returns the output.
+#>
+function Invoke-WSLExecutable {
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true)]
+		# The absolute path of the executable in WSL.
+		[string]$FilePath,
+
+		[Parameter(Mandatory = $false)]
+		# Arguments passed directly to the executable.
+		[string[]]$ArgumentList = @(),
+
+		[Parameter(Mandatory = $false)]
+		# If true, the executable is run as root. If false, it is run as the default user.
+		[switch]$Root
+	)
+
+	$wslArgs = @()
+
+	if ($Root) {
+		$wslArgs += '--user'
+		$wslArgs += 'root'
+	}
+
+	$wslArgs += '--exec'
+	$wslArgs += $FilePath
+	$wslArgs += $ArgumentList
+
+	& wsl $wslArgs
+
+	$exitCode = $LASTEXITCODE
+	if ($exitCode -ne 0) {
+		$displayCommand = (@($FilePath) + $ArgumentList) -join ' '
+		throw "WSL executable failed with exit code ${exitCode}: $displayCommand"
+	}
+}
+
+<#
+	.SYNOPSIS
 	Runs a command in WSL and returns the output.
 
 	.NOTES
@@ -183,31 +223,16 @@ function Invoke-WSLCommand {
 		[switch]$Interactive
 	)
 
-	$wslArgs = @()
-
-	if ($Root) {
-		$wslArgs += '--user'
-		$wslArgs += 'root'
-	}
-
-	$wslArgs += '--exec'
-	$wslArgs += '/usr/bin/env'
-	$wslArgs += 'bash'
+	$argumentList = @('bash')
 
 	if ($Interactive) {
-		$wslArgs += '-i'
+		$argumentList += '-i'
 	}
 
-	$wslArgs += '-c'
-	$wslArgs += $Command
+	$argumentList += '-c'
+	$argumentList += $Command
 
-	# Do not use Invoke-Expression to avoid re-interpretation of the command string
-	& wsl $wslArgs
-
-	$exitCode = $LASTEXITCODE
-	if ($exitCode -ne 0) {
-		throw "WSL command failed with exit code ${exitCode}: $Command"
-	}
+	Invoke-WSLExecutable -FilePath '/usr/bin/env' -ArgumentList $argumentList -Root:$Root
 }
 
 <#
@@ -283,12 +308,18 @@ function New-WslUser {
 
 	# No need to check the duplicate username because useradd will fail if it exists
 	# Omitting --password leaves password authentication locked.
-	Invoke-WSLCommand -Root -Command "useradd --create-home $Username"
-	Invoke-WSLCommand -Root -Command "usermod --append --groups sudo $Username"
+	Invoke-WSLExecutable `
+		-Root `
+		-FilePath '/usr/sbin/useradd' `
+		-ArgumentList @('--create-home', '--', $Username)
+	Invoke-WSLExecutable `
+		-Root `
+		-FilePath '/usr/sbin/usermod' `
+		-ArgumentList @('--append', '--groups', 'sudo', '--', $Username)
 
 	# The WSL setup script needs sudo before it can link the managed sudoers file.
 	$sudoersPath = '/etc/sudoers.d/01-users-nopasswd'
-	Invoke-WSLCommand -Root -Command 'install --directory --mode=0755 /etc/sudoers.d'
+	Invoke-WSLExecutable -Root -FilePath '/usr/bin/mkdir' -ArgumentList @('--parents', '/etc/sudoers.d')
 	Invoke-WSLCommand -Root -Command (
 		"printf '%s\n' 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' > $sudoersPath && " +
 		"chmod 0440 $sudoersPath"

--- a/wsl/etc/sudoers.d/01-users-nopasswd
+++ b/wsl/etc/sudoers.d/01-users-nopasswd
@@ -1,3 +1,0 @@
-# allow all users to run all commands without password
-# cspell:ignore nopasswd
-ALL ALL=(ALL:ALL) NOPASSWD: ALL

--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -115,50 +115,27 @@ clone_or_update_dotfiles_repo() {
 	echo "${dotfiles_target_dir}"
 }
 
-create_etc_symlinks() {
-	local wsl_config_dir="$1"
-	local repo_root
-	repo_root="$(realpath "${wsl_config_dir}/..")"
-	local wsl_etc_config_dir
-	wsl_etc_config_dir="$(realpath "${wsl_config_dir}/etc")"
-
-	log_info "Creating symbolic links for etc directory files from ${wsl_etc_config_dir}..."
-	local wsl_etc_config_relative_dir
-	wsl_etc_config_relative_dir="$(realpath --relative-to="${repo_root}" "${wsl_etc_config_dir}")"
-	local etc_paths=()
-	# A git failure leaves the array empty and is handled below.
-	# shellcheck disable=SC2312
-	while IFS= read -r -d '' path; do
-		etc_paths+=("${repo_root}/${path}")
-	done < <(git -C "${repo_root}" ls-files -z -- "${wsl_etc_config_relative_dir}")
-
-	if ((${#etc_paths[@]} == 0)); then
-		log_error "No etc directory files found to symlink."
-		exit 1
+migrate_legacy_sudoers_symlink() {
+	local sudoers_path=/etc/sudoers.d/01-users-nopasswd
+	if [[ ! -L ${sudoers_path} ]]; then
+		return
 	fi
 
-	for path in "${etc_paths[@]}"; do
-		local full_path
-		full_path=$(realpath "${path}")
-		local target_name
-		target_name="$(realpath --relative-to="${wsl_etc_config_dir}" "${full_path}")"
-		local target_path="/etc/${target_name}"
-
-		sudo mkdir --parents "$(dirname "${target_path}")"
-		sudo ln --symbolic --no-dereference --force "${full_path}" "${target_path}"
-		sudo chown root:root "${target_path}"
-		log_info "Installed symlink: ${target_path}"
-	done
+	log_info "Replacing legacy sudoers symlink with a root-owned file..."
+	local sudoers_temporary_path=/etc/sudoers.d/.01-users-nopasswd.tmp
+	printf '%s\n' 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' |
+		sudo tee "${sudoers_temporary_path}" >/dev/null
+	sudo chmod 0440 "${sudoers_temporary_path}"
+	sudo mv --force "${sudoers_temporary_path}" "${sudoers_path}"
+	log_info "Legacy sudoers symlink replaced."
 }
 
 main() {
 	install_mise
+	migrate_legacy_sudoers_symlink
 
 	local dotfiles_dir
 	dotfiles_dir=$(clone_or_update_dotfiles_repo "${git_ref}")
-
-	local wsl_config_dir="${dotfiles_dir}/wsl"
-	create_etc_symlinks "${wsl_config_dir}"
 
 	log_info "Bootstrapping packages, dotfiles, and tools with mise..."
 	mise trust --yes "${dotfiles_dir}/mise.toml"

--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -115,24 +115,8 @@ clone_or_update_dotfiles_repo() {
 	echo "${dotfiles_target_dir}"
 }
 
-migrate_legacy_sudoers_symlink() {
-	local sudoers_path=/etc/sudoers.d/01-users-nopasswd
-	if [[ ! -L ${sudoers_path} ]]; then
-		return
-	fi
-
-	log_info "Replacing legacy sudoers symlink with a root-owned file..."
-	local sudoers_temporary_path=/etc/sudoers.d/.01-users-nopasswd.tmp
-	printf '%s\n' 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' |
-		sudo tee "${sudoers_temporary_path}" >/dev/null
-	sudo chmod 0440 "${sudoers_temporary_path}"
-	sudo mv --force "${sudoers_temporary_path}" "${sudoers_path}"
-	log_info "Legacy sudoers symlink replaced."
-}
-
 main() {
 	install_mise
-	migrate_legacy_sudoers_symlink
 
 	local dotfiles_dir
 	dotfiles_dir=$(clone_or_update_dotfiles_repo "${git_ref}")


### PR DESCRIPTION
## Summary

- create the initial WSL user with a locked password
- remove the password prompts and `chpasswd` flow
- pass WSL user-management arguments without shell parsing
- seed the existing `NOPASSWD` policy as root before the user-side bootstrap needs `sudo`
- persist the sudoers policy through mise's pre-packages hook
- remove the one-file `wsl/etc` tree and generic system-file symlinking machinery

## Why

The WSL user does not need password authentication because this setup already grants passwordless sudo, and Windows users with access to the distribution can launch WSL as root directly.

The previous implementation embedded the plaintext password in an unquoted `bash -c` command. Shell metacharacters in a password could be interpreted as command syntax, and the password was temporarily exposed in process arguments.

The only remaining file under `wsl/etc` duplicated the sudoers policy now needed before bootstrap. Keeping a generic root-owned symlink layer for that one file added unnecessary installer complexity.

## Impact

Fresh Windows installations no longer prompt for a WSL password. The Windows installer seeds the sudoers file so the locked user can run the first bootstrap, and mise enforces the same policy on every bootstrap.

Existing installations keep the same `NOPASSWD` policy. Mise replaces the legacy path with a regular root-owned file the next time bootstrap runs.

A WSL-only installation with a normal Ubuntu user may request that user's existing password while installing mise; the pre-packages hook then configures passwordless sudo.

This is a follow-up to the discussion in #1868; it does not adopt cloud-init.

Closes #1966.

## Validation

- `mise run check --lint` using mise 2026.7.7
- Ubuntu 26.04 container verification: the new account reports locked password status (`L`) and `sudo --non-interactive id --user` returns `0`
- mise sudoers replacement verification: the result is a regular `root:root` file with mode `0440`, accepted by `visudo --check`
