### PR TITLE
fix(git): correct user name

### DIFF
--- a/wsl/home/.gitconfig
+++ b/wsl/home/.gitconfig
@@ -2,7 +2,7 @@
 	defaultBranch = main
 
 [user]
-	name = Taku Kodma
+	name = Taku Kodama
 	email = 79110363+risu729@users.noreply.github.com
 	signingKey = "key::ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMor6SlX/qQY6DlSPNshh+HuBxu2VqRrnF0goRw1p3u8"
 


### PR DESCRIPTION
## Summary

- Correct the managed Git author name from `Taku Kodma` to `Taku Kodama`.

## Why

The hardcoded Git identity contained a spelling error, so new commits inherited the incorrect author name.

## Impact

New WSL environments, and existing environments after applying the managed dotfiles, use the correctly spelled Git author name.

## Validation

- `git config --file wsl/home/.gitconfig --get user.name`
- `git diff --check`
- `hk run pre-commit --from-hook` using the repository-pinned `hk`, `typos`, and `betterleaks` binaries

## Summary by Sourcery

Bug Fixes:
- Fix the hardcoded Git author name spelling in the managed .gitconfig so commits use the correct user name.