### PR TITLE
feat(git): add CSE GitLab setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ This repository is organized around the two installer entry points:
   - `wsl/home/` mirrors the target home directory. Mise links these files into
     `$HOME`, except for Codex skills, which are copied because Codex does not
     discover symlinked skill files.
-  - `wsl/setup-git.ts` performs interactive GitHub authentication after the
-    base WSL environment is ready. Git identity, SSH signing, and `ghr`
-    defaults live in `wsl/home/.gitconfig` and `wsl/home/.ghr/ghr.toml`.
+  - `wsl/setup-git.ts` performs interactive GitHub and UNSW CSE GitLab
+    authentication after the base WSL environment is ready. Git identity, SSH
+    signing, and `ghr` defaults live in `wsl/home/.gitconfig` and
+    `wsl/home/.ghr/ghr.toml`.
 
 - `worker/` is a Cloudflare Worker for `dot.risunosu.com`. It redirects the root
   route to this README and serves the `/win` and `/wsl` installer routes by

--- a/wsl/home/.config/git/unsw.gitconfig
+++ b/wsl/home/.config/git/unsw.gitconfig
@@ -1,0 +1,2 @@
+[user]
+	email = 14969-z5642102@users.noreply.gitlab2.cse.unsw.edu.au

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -38,6 +38,7 @@ watchexec = "latest"
 jq = "latest"
 yq = "latest"
 github-cli = "latest"
+glab = "latest"
 "github:seachicken/gh-poi" = { version = "latest", bin = "gh-poi" }
 "aqua:siketyan/ghr" = { version = "latest", prerelease = true }
 fzf = "latest"

--- a/wsl/home/.config/mise/mise.lock
+++ b/wsl/home/.config/mise/mise.lock
@@ -1154,6 +1154,55 @@ checksum = "sha256:3c3cd0ee3afc3fbba5adacef483ca4ba2b5d1a47a2184b34489324fb7edfa
 url = "https://github.com/seachicken/gh-poi/releases/download/v0.18.1/darwin-amd64"
 url_api = "https://api.github.com/repos/seachicken/gh-poi/releases/assets/447018953"
 
+[[tools.glab]]
+version = "1.108.0"
+backend = "gitlab:gitlab-org/cli"
+
+[tools.glab."platforms.linux-arm64"]
+checksum = "sha256:681031c6477dc7eb53b07a4641e2defc6795cf7ffb18ddc6cf8bdbc1211ed782"
+url = "https://gitlab.com/gitlab-org/cli/-/releases/v1.108.0/downloads/glab_1.108.0_linux_arm64.tar.gz"
+url_api = "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/1%2E108%2E0/glab_1%2E108%2E0_linux_arm64%2Etar%2Egz"
+
+[tools.glab."platforms.linux-arm64-musl"]
+checksum = "sha256:681031c6477dc7eb53b07a4641e2defc6795cf7ffb18ddc6cf8bdbc1211ed782"
+url = "https://gitlab.com/gitlab-org/cli/-/releases/v1.108.0/downloads/glab_1.108.0_linux_arm64.tar.gz"
+url_api = "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/1%2E108%2E0/glab_1%2E108%2E0_linux_arm64%2Etar%2Egz"
+
+[tools.glab."platforms.linux-x64"]
+checksum = "sha256:cb3eb9d6b05eedef24a028b52354f12fb9a07ecfa0b5581eb161176585bc8213"
+url = "https://gitlab.com/gitlab-org/cli/-/releases/v1.108.0/downloads/glab_1.108.0_linux_amd64.tar.gz"
+url_api = "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/1%2E108%2E0/glab_1%2E108%2E0_linux_amd64%2Etar%2Egz"
+
+[tools.glab."platforms.linux-x64-baseline"]
+checksum = "sha256:cb3eb9d6b05eedef24a028b52354f12fb9a07ecfa0b5581eb161176585bc8213"
+url = "https://gitlab.com/gitlab-org/cli/-/releases/v1.108.0/downloads/glab_1.108.0_linux_amd64.tar.gz"
+url_api = "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/1%2E108%2E0/glab_1%2E108%2E0_linux_amd64%2Etar%2Egz"
+
+[tools.glab."platforms.linux-x64-musl"]
+checksum = "sha256:cb3eb9d6b05eedef24a028b52354f12fb9a07ecfa0b5581eb161176585bc8213"
+url = "https://gitlab.com/gitlab-org/cli/-/releases/v1.108.0/downloads/glab_1.108.0_linux_amd64.tar.gz"
+url_api = "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/1%2E108%2E0/glab_1%2E108%2E0_linux_amd64%2Etar%2Egz"
+
+[tools.glab."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:cb3eb9d6b05eedef24a028b52354f12fb9a07ecfa0b5581eb161176585bc8213"
+url = "https://gitlab.com/gitlab-org/cli/-/releases/v1.108.0/downloads/glab_1.108.0_linux_amd64.tar.gz"
+url_api = "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/1%2E108%2E0/glab_1%2E108%2E0_linux_amd64%2Etar%2Egz"
+
+[tools.glab."platforms.macos-arm64"]
+checksum = "sha256:56973be8636a633b0135294ca73ba8e0a598b9bce6a2063841ce267ab21c6022"
+url = "https://gitlab.com/gitlab-org/cli/-/releases/v1.108.0/downloads/glab_1.108.0_darwin_arm64.tar.gz"
+url_api = "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/1%2E108%2E0/glab_1%2E108%2E0_darwin_arm64%2Etar%2Egz"
+
+[tools.glab."platforms.macos-x64"]
+checksum = "sha256:630d7b3cdb708f78cefc475e32f14d1bef493162acc43eacbd400a95178f5562"
+url = "https://gitlab.com/gitlab-org/cli/-/releases/v1.108.0/downloads/glab_1.108.0_darwin_amd64.tar.gz"
+url_api = "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/1%2E108%2E0/glab_1%2E108%2E0_darwin_amd64%2Etar%2Egz"
+
+[tools.glab."platforms.macos-x64-baseline"]
+checksum = "sha256:630d7b3cdb708f78cefc475e32f14d1bef493162acc43eacbd400a95178f5562"
+url = "https://gitlab.com/gitlab-org/cli/-/releases/v1.108.0/downloads/glab_1.108.0_darwin_amd64.tar.gz"
+url_api = "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/packages/generic/glab/1%2E108%2E0/glab_1%2E108%2E0_darwin_amd64%2Etar%2Egz"
+
 [[tools.glow]]
 version = "2.1.2"
 backend = "aqua:charmbracelet/glow"

--- a/wsl/home/.gitconfig
+++ b/wsl/home/.gitconfig
@@ -31,6 +31,13 @@
 [credential "https://gist.github.com"]
 	helper =
 	helper = !gh auth git-credential
+[credential "https://gitlab.cse.unsw.edu.au"]
+	username = z5642102
+	helper =
+	helper = !glab auth git-credential
+
+[includeIf "gitdir:~/.ghr/gitlab.cse.unsw.edu.au/"]
+	path = ~/.config/git/unsw.gitconfig
 
 [include]
 	path = ~/.gitconfig.local

--- a/wsl/setup-git.ts
+++ b/wsl/setup-git.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 
-import { resolve } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
 import { $, env, spawn } from "bun";
 
@@ -9,6 +11,16 @@ import { $, env, spawn } from "bun";
 // Remove GITHUB_TOKEN from env to avoid github cli using it
 const envWithoutGitHubToken = Object.fromEntries(
 	Object.entries(env).filter(([key]) => key !== "GITHUB_TOKEN"),
+) as Record<string, string>;
+
+const gitLabHost = "gitlab.cse.unsw.edu.au";
+const gitLabTokenEnvironmentVariables = new Set([
+	"GITLAB_TOKEN",
+	"GITLAB_ACCESS_TOKEN",
+	"OAUTH_TOKEN",
+]);
+const envWithoutGitLabTokens = Object.fromEntries(
+	Object.entries(env).filter(([key]) => !gitLabTokenEnvironmentVariables.has(key)),
 ) as Record<string, string>;
 
 const ensureGitHubTokenScopes = async (): Promise<void> => {
@@ -103,6 +115,47 @@ const ensureGitHubTokenScopes = async (): Promise<void> => {
 	}
 };
 
+const ensureGitLabAuthentication = async (): Promise<void> => {
+	const { exitCode } = await $`glab auth status --hostname ${gitLabHost}`
+		.env(envWithoutGitLabTokens)
+		.quiet()
+		.nothrow();
+	if (exitCode === 0) {
+		return;
+	}
+
+	console.info(`Authenticate with ${gitLabHost} using a fine-grained personal access token.
+Use all groups and projects with these permissions:
+- User: Read
+- Code: Download
+- Code: Push`);
+	await $`xdg-open ${`https://${gitLabHost}/-/user_settings/personal_access_tokens`}`.nothrow();
+
+	// Keep glab from editing the managed ~/.gitconfig during interactive login.
+	// The GitLab credential helper is already configured in wsl/home/.gitconfig.
+	const temporaryDirectory = await mkdtemp(join(tmpdir(), "dotfiles-glab-"));
+	try {
+		const process = spawn(
+			["glab", "auth", "login", "--hostname", gitLabHost, "--git-protocol", "https"],
+			{
+				env: {
+					...envWithoutGitLabTokens,
+					GIT_CONFIG_GLOBAL: join(temporaryDirectory, "gitconfig"),
+				},
+				stderr: "inherit",
+				stdin: "inherit",
+				stdout: "inherit",
+			},
+		);
+		const processExitCode = await process.exited;
+		if (processExitCode !== 0) {
+			throw new Error(`glab auth login exited with code ${processExitCode}.`);
+		}
+	} finally {
+		await rm(temporaryDirectory, { force: true, recursive: true });
+	}
+};
+
 const main = async (): Promise<void> => {
 	try {
 		await ensureGitHubTokenScopes();
@@ -111,5 +164,6 @@ const main = async (): Promise<void> => {
 		const ghConfigPath = resolve(import.meta.dirname, "./home/.config/gh/config.yml");
 		await $`git checkout -- ${ghConfigPath}`.cwd(resolve(import.meta.dirname, "..")).quiet();
 	}
+	await ensureGitLabAuthentication();
 };
 await main();


### PR DESCRIPTION
## Summary

- install GitLab CLI through the managed mise tool configuration and lockfile
- authenticate `glab` against the active `gitlab.cse.unsw.edu.au` instance during Git bootstrap
- configure `glab auth git-credential` for Git-over-HTTPS
- apply the UNSW private commit email automatically to repositories cloned by `ghr` under `~/.ghr/gitlab.cse.unsw.edu.au/`

## Why

UNSW CSE is moving teaching repositories to `gitlab.cse.unsw.edu.au`, while the `nw-syd-gitlab.cseunsw.tech` instance is deprecated and becoming read-only. The dotfiles previously bootstrapped GitHub only, leaving GitLab installation, authentication, and commit identity as manual setup.

## Impact

The interactive bootstrap opens the CSE personal access token page and requests a fine-grained token with `User: Read`, `Code: Download`, and `Code: Push`. Repositories cloned over HTTPS with `ghr clone` then use the host-specific credential helper and private CSE commit email automatically. The deprecated `nw-syd` host is intentionally not configured.

The login runs with a temporary global Git configuration so `glab` cannot rewrite the managed dotfiles; credentials remain in glab's own credential storage.

## Validation

- generated and resolved the locked `glab` 1.108.0 mise entry
- `hk run pre-commit --from-hook`
- `tsc --noEmit`
- `oxlint wsl/setup-git.ts`
- `tombi lint` on the managed mise configuration and lockfile
- simulated `ghr` directory layouts and verified CSE GitLab receives the private GitLab email while GitHub retains the GitHub noreply email

## Summary by Sourcery

Integrate UNSW CSE GitLab into the WSL dotfiles Git setup alongside GitHub.

New Features:
- Add interactive GitLab authentication via glab during WSL Git bootstrap.
- Install and manage the GitLab CLI glab through the shared mise configuration and lockfile.
- Introduce UNSW-specific Git configuration for GitLab-hosted repositories, including commit identity defaults.

Enhancements:
- Ensure GitLab authentication runs with a temporary global Git configuration to keep managed dotfiles immutable.