### PR TITLE
fix(git): make CSE GitLab auth manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ This repository is organized around the two installer entry points:
   - `wsl/home/` mirrors the target home directory. Mise links these files into
     `$HOME`, except for Codex skills, which are copied because Codex does not
     discover symlinked skill files.
-  - `wsl/setup-git.ts` performs interactive GitHub and UNSW CSE GitLab
-    authentication after the base WSL environment is ready. Git identity, SSH
-    signing, and `ghr` defaults live in `wsl/home/.gitconfig` and
-    `wsl/home/.ghr/ghr.toml`.
+  - `wsl/setup-git.ts` performs interactive GitHub authentication after the
+    base WSL environment is ready. Git identity, SSH signing, and `ghr`
+    defaults live in `wsl/home/.gitconfig` and `wsl/home/.ghr/ghr.toml`.
 
 - `worker/` is a Cloudflare Worker for `dot.risunosu.com`. It redirects the root
   route to this README and serves the `/win` and `/wsl` installer routes by
@@ -100,6 +99,37 @@ bash -i <(curl -fsSL https://dot.risunosu.com/wsl)
 >
 > Both installer scripts are idempotent, meaning you can run them multiple times
 > without issues.
+
+### UNSW CSE GitLab
+
+Mise installs `glab`, but authentication with the CSE GitLab instance is
+manual. Create a fine-grained personal access token at
+<https://gitlab.cse.unsw.edu.au/-/user_settings/personal_access_tokens> with
+access to all groups and projects and these permissions:
+
+- `User: Read`
+- `Code: Download`
+- `Code: Push`
+
+Pass the token to `glab` over standard input to avoid the OAuth flow, which is
+not configured on the CSE GitLab instance:
+
+```bash
+read -rsp "GitLab token: " gitlab_token
+printf '\n'
+printf '%s' "$gitlab_token" | glab auth login \
+  --hostname gitlab.cse.unsw.edu.au \
+  --git-protocol https \
+  --stdin
+unset gitlab_token
+```
+
+Repositories cloned from this host with `ghr` automatically use the CSE private
+commit email and the `glab` HTTPS credential helper:
+
+```bash
+ghr clone https://gitlab.cse.unsw.edu.au/GROUP/PROJECT.git
+```
 
 ## ➡️ What to Do Next
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ access to all groups and projects and these permissions:
 - `Code: Push`
 
 Pass the token to `glab` over standard input to avoid the OAuth flow, which is
-not configured on the CSE GitLab instance:
+not configured on the CSE GitLab instance. `glab` stores the token in
+`~/.config/glab-cli/config.yml`; keep this file readable only by the WSL user
+(`0600`).
 
 ```bash
 read -rsp "GitLab token: " gitlab_token

--- a/wsl/setup-git.ts
+++ b/wsl/setup-git.ts
@@ -1,8 +1,6 @@
 #!/usr/bin/env bun
 
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 
 import { $, env, spawn } from "bun";
 
@@ -11,16 +9,6 @@ import { $, env, spawn } from "bun";
 // Remove GITHUB_TOKEN from env to avoid github cli using it
 const envWithoutGitHubToken = Object.fromEntries(
 	Object.entries(env).filter(([key]) => key !== "GITHUB_TOKEN"),
-) as Record<string, string>;
-
-const gitLabHost = "gitlab.cse.unsw.edu.au";
-const gitLabTokenEnvironmentVariables = new Set([
-	"GITLAB_TOKEN",
-	"GITLAB_ACCESS_TOKEN",
-	"OAUTH_TOKEN",
-]);
-const envWithoutGitLabTokens = Object.fromEntries(
-	Object.entries(env).filter(([key]) => !gitLabTokenEnvironmentVariables.has(key)),
 ) as Record<string, string>;
 
 const ensureGitHubTokenScopes = async (): Promise<void> => {
@@ -115,47 +103,6 @@ const ensureGitHubTokenScopes = async (): Promise<void> => {
 	}
 };
 
-const ensureGitLabAuthentication = async (): Promise<void> => {
-	const { exitCode } = await $`glab auth status --hostname ${gitLabHost}`
-		.env(envWithoutGitLabTokens)
-		.quiet()
-		.nothrow();
-	if (exitCode === 0) {
-		return;
-	}
-
-	console.info(`Authenticate with ${gitLabHost} using a fine-grained personal access token.
-Use all groups and projects with these permissions:
-- User: Read
-- Code: Download
-- Code: Push`);
-	await $`xdg-open ${`https://${gitLabHost}/-/user_settings/personal_access_tokens`}`.nothrow();
-
-	// Keep glab from editing the managed ~/.gitconfig during interactive login.
-	// The GitLab credential helper is already configured in wsl/home/.gitconfig.
-	const temporaryDirectory = await mkdtemp(join(tmpdir(), "dotfiles-glab-"));
-	try {
-		const process = spawn(
-			["glab", "auth", "login", "--hostname", gitLabHost, "--git-protocol", "https"],
-			{
-				env: {
-					...envWithoutGitLabTokens,
-					GIT_CONFIG_GLOBAL: join(temporaryDirectory, "gitconfig"),
-				},
-				stderr: "inherit",
-				stdin: "inherit",
-				stdout: "inherit",
-			},
-		);
-		const processExitCode = await process.exited;
-		if (processExitCode !== 0) {
-			throw new Error(`glab auth login exited with code ${processExitCode}.`);
-		}
-	} finally {
-		await rm(temporaryDirectory, { force: true, recursive: true });
-	}
-};
-
 const main = async (): Promise<void> => {
 	try {
 		await ensureGitHubTokenScopes();
@@ -164,6 +111,5 @@ const main = async (): Promise<void> => {
 		const ghConfigPath = resolve(import.meta.dirname, "./home/.config/gh/config.yml");
 		await $`git checkout -- ${ghConfigPath}`.cwd(resolve(import.meta.dirname, "..")).quiet();
 	}
-	await ensureGitLabAuthentication();
 };
 await main();


### PR DESCRIPTION
## Summary

- remove CSE GitLab authentication from `wsl/setup-git.ts`
- restore the bootstrap script to GitHub-only authentication
- document manual fine-grained-token authentication with `glab auth login --stdin`
- document `glab`'s local token storage and required file permissions
- retain the mise-managed `glab` installation, HTTPS credential helper, private commit email, and `ghr` directory matching

## Why

Interactive `glab auth login` selected the OAuth flow on `gitlab.cse.unsw.edu.au`. That self-managed instance does not configure a `glab` OAuth client ID, so bootstrap failed with:

```text
Set 'client_id' first with glab config set client_id <client_id> -g --host gitlab.cse.unsw.edu.au.
```

Authentication is a one-time manual operation, so keeping it out of the otherwise repeatable bootstrap avoids coupling installation to server-specific OAuth configuration.

## Impact

Bootstrap no longer prompts for or attempts CSE GitLab authentication. The README explains how to create the fine-grained token and pass it over standard input, bypassing OAuth without placing the token in shell history. `glab` stores the credential in `~/.config/glab-cli/config.yml`, which should remain mode `0600`. After login, `ghr clone` continues to use the managed CSE identity and HTTPS credential helper.

## Validation

- `hk run pre-commit --from-hook`
- TypeScript type checking and linting through the pre-commit suite
- Markdown formatting and linting through the pre-commit suite

## Summary by Sourcery

Remove automated UNSW CSE GitLab authentication from the WSL Git setup script and document manual GitLab token-based authentication using glab.

New Features:
- Document manual fine-grained-token authentication for UNSW CSE GitLab using glab auth login with stdin, including recommended permissions and usage with ghr clone.

Enhancements:
- Simplify wsl/setup-git.ts to focus solely on GitHub authentication and avoid GitLab-specific environment handling and temporary config manipulation.
