### PR TITLE
docs(git): simplify CSE GitLab login

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,34 +103,12 @@ bash -i <(curl -fsSL https://dot.risunosu.com/wsl)
 ### UNSW CSE GitLab
 
 Mise installs `glab`, but authentication with the CSE GitLab instance is
-manual. Create a personal access token at
-<https://gitlab.cse.unsw.edu.au/-/user_settings/personal_access_tokens> with
-these scopes:
-
-- `api`, which lets `glab` create and manage resources such as issues and merge
-  requests
-- `write_repository`, which grants both pull and push access over HTTPS
-
-Pass the token to `glab` over standard input to avoid configuring an OAuth
-client ID for this host. `glab` stores the token in
-`~/.config/glab-cli/config.yml`; keep this file readable only by the WSL user
-(`0600`).
+manual. Run:
 
 ```bash
-read -rsp "GitLab token: " gitlab_token
-printf '\n'
-printf '%s' "$gitlab_token" | glab auth login \
+glab auth login \
   --hostname gitlab.cse.unsw.edu.au \
-  --git-protocol https \
-  --stdin
-unset gitlab_token
-```
-
-Repositories cloned from this host with `ghr` automatically use the CSE private
-commit email and the `glab` HTTPS credential helper:
-
-```bash
-ghr clone https://gitlab.cse.unsw.edu.au/GROUP/PROJECT.git
+  --git-protocol https
 ```
 
 ## ➡️ What to Do Next

--- a/README.md
+++ b/README.md
@@ -103,13 +103,12 @@ bash -i <(curl -fsSL https://dot.risunosu.com/wsl)
 ### UNSW CSE GitLab
 
 Mise installs `glab`, but authentication with the CSE GitLab instance is
-manual. Create a fine-grained personal access token at
+manual. Create a personal access token at
 <https://gitlab.cse.unsw.edu.au/-/user_settings/personal_access_tokens> with
-access to all groups and projects and these permissions:
+these scopes:
 
-- `User: Read`
-- `Code: Download`
-- `Code: Push`
+- `read_user`, which lets `glab` validate the login through the `/user` API
+- `write_repository`, which grants both pull and push access over HTTPS
 
 Pass the token to `glab` over standard input to avoid the OAuth flow, which is
 not configured on the CSE GitLab instance. `glab` stores the token in

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ manual. Create a personal access token at
 <https://gitlab.cse.unsw.edu.au/-/user_settings/personal_access_tokens> with
 these scopes:
 
-- `read_user`, which lets `glab` validate the login through the `/user` API
+- `api`, which lets `glab` create and manage resources such as issues and merge
+  requests
 - `write_repository`, which grants both pull and push access over HTTPS
 
 Pass the token to `glab` over standard input to avoid the OAuth flow, which is

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ these scopes:
   requests
 - `write_repository`, which grants both pull and push access over HTTPS
 
-Pass the token to `glab` over standard input to avoid the OAuth flow, which is
-not configured on the CSE GitLab instance. `glab` stores the token in
+Pass the token to `glab` over standard input to avoid configuring an OAuth
+client ID for this host. `glab` stores the token in
 `~/.config/glab-cli/config.yml`; keep this file readable only by the WSL user
 (`0600`).
 


### PR DESCRIPTION
## Summary

- document the interactive `glab auth login` command for the CSE GitLab instance
- configure Git-over-HTTPS through the login command
- remove token-scope, credential-storage, OAuth, and `ghr` details

## Why

Authentication choices and credential handling are presented interactively by `glab`. Keeping the README focused on the command avoids duplicating or overexplaining those details.

## Impact

The CSE GitLab setup documentation now contains only the command needed to start authentication.

## Validation

- `hk run pre-commit --from-hook`

## Summary by Sourcery

Documentation:
- Streamline CSE GitLab setup documentation to only describe running `glab auth login` with HTTPS, removing detailed token, OAuth, credential storage, and `ghr` usage guidance.