### PR TITLE
fix(win): create main sudoers file

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -59,10 +59,9 @@ includes = ["tasks.toml", "tasks", "worker/tasks.toml", "worker/tasks"]
 
 [bootstrap.hooks.pre-packages]
 run = '''
-# Persist passwordless sudo and replace the legacy repository symlink if present.
-sudo mkdir --parents /etc/sudoers.d
-sudoers_path=/etc/sudoers.d/01-users-nopasswd
-sudoers_temporary_path=/etc/sudoers.d/.01-users-nopasswd.tmp
+# Persist passwordless sudo in the main policy file.
+sudoers_path=/etc/sudoers
+sudoers_temporary_path=/etc/.sudoers.tmp
 printf '%s\n' 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' |
   sudo tee "${sudoers_temporary_path}" >/dev/null
 sudo chmod 0440 "${sudoers_temporary_path}"

--- a/win/install.ps1
+++ b/win/install.ps1
@@ -318,8 +318,7 @@ function New-WslUser {
 		-ArgumentList @('--append', '--groups', 'sudo', '--', $Username)
 
 	# The WSL setup script needs sudo before mise can persist the sudoers policy.
-	$sudoersPath = '/etc/sudoers.d/01-users-nopasswd'
-	Invoke-WSLExecutable -Root -FilePath '/usr/bin/mkdir' -ArgumentList @('--parents', '/etc/sudoers.d')
+	$sudoersPath = '/etc/sudoers'
 	Invoke-WSLCommand -Root -Command (
 		"printf '%s\n' 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' > $sudoersPath && " +
 		"chmod 0440 $sudoersPath"


### PR DESCRIPTION
## Summary

- create the passwordless policy directly as `/etc/sudoers` during WSL user setup
- persist the same main policy file from the mise pre-packages hook
- remove the now-unnecessary `/etc/sudoers.d` directory setup

## Why

The minimal WSL image does not necessarily provide a main `/etc/sudoers` file that includes `/etc/sudoers.d`. Creating only `/etc/sudoers.d/01-users-nopasswd` can therefore leave the newly created locked-password user unable to run `sudo` during the first bootstrap.

Writing the policy directly to `/etc/sudoers` makes the initial sudo configuration self-contained and lets mise preserve the same policy afterward.

## Impact

Fresh Windows-driven WSL installations can use passwordless sudo even when the imported image does not already have a functional main sudoers configuration. WSL-only installations retain the same passwordless policy after bootstrap.

Closes #1966.

## Validation

- `printf '%s\n' 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' | visudo --check --file=-`
- `mise run check --lint` with mise 2026.7.7

## Summary by Sourcery

Ensure WSL-created users have a functional passwordless sudo configuration by writing the policy directly to the main sudoers file and aligning bootstrap hooks with this setup.

Bug Fixes:
- Fix initial WSL user bootstrap so passwordless sudo works even when the image lacks a preconfigured /etc/sudoers including /etc/sudoers.d.

Enhancements:
- Align the mise pre-packages hook with the WSL setup to persist the same main /etc/sudoers passwordless policy and stop managing a separate sudoers.d entry.