### PR TITLE
feat(agents): share config with Cursor and Claude Code

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -102,8 +102,10 @@ dotfiles_root=$(git rev-parse --show-toplevel)
 ln --symbolic --no-dereference --force \
   "${dotfiles_root}/wsl/home/.gitconfig" "${HOME}/.gitconfig"
 
-mise exec -- gh skill install mattpocock/skills skills/productivity/grilling \
-  --agent universal --scope user --pin main --force
+for agent in universal claude-code; do
+  mise exec -- gh skill install mattpocock/skills skills/productivity/grilling \
+    --agent "${agent}" --scope user --pin main --force
+done
 '''
 
 [bootstrap.hooks.final]
@@ -159,8 +161,10 @@ login_shell = "/bin/bash"
 [dotfiles]
 "~/.agents" = { source = "wsl/home/.agents", mode = "copy" }
 "~/.bashrc" = "wsl/home/.bashrc"
+"~/.claude/CLAUDE.md" = "wsl/home/.codex/AGENTS.md"
 "~/.codex" = { source = "wsl/home/.codex", mode = "symlink-each" }
 "~/.config" = { source = "wsl/home/.config", mode = "symlink-each" }
+"~/.cursor/rules/global/RULE.md" = "wsl/home/.codex/AGENTS.md"
 "~/.ghr" = { source = "wsl/home/.ghr", mode = "symlink-each" }
 "~/.hushlogin" = "wsl/home/.hushlogin"
 "~/.local" = { source = "wsl/home/.local", mode = "symlink-each" }


### PR DESCRIPTION
## Summary

- expose the existing global agent instructions as Claude Code and Cursor global configuration
- install the grilling skill into Claude Code's user skill directory in addition to the universal agent directory

## Why

This keeps Codex, Claude Code, and Cursor on the same declarative global instructions while preserving a single source file in the dotfiles repository. It also makes the existing grilling skill available to Claude Code without duplicating its contents.

## Validation

- `mise bootstrap dotfiles apply --dry-run --yes`
- `mise run check --lint`

## Summary by Sourcery

Share global agent configuration and skills across Codex, Claude Code, and Cursor.

New Features:
- Expose shared global agent instructions to Claude Code and Cursor via new dotfile mappings.
- Install the existing grilling skill for both the universal agent and Claude Code user scopes.

Enhancements:
- Extend dotfiles bootstrap to keep agent configuration centralized while supporting additional editors.