### PR TITLE
chore(git): remove unused local config include

### DIFF
--- a/wsl/home/.gitconfig
+++ b/wsl/home/.gitconfig
@@ -39,9 +39,6 @@
 [includeIf "gitdir:~/.ghr/gitlab.cse.unsw.edu.au/"]
 	path = ~/.config/git/unsw.gitconfig
 
-[include]
-	path = ~/.gitconfig.local
-
 [alias]
 	sm = "!branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null); branch=${branch#origin/}; if [ -z \"$branch\" ]; then branch=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p'); fi; [ -n \"$branch\" ] && git switch \"$branch\""
 	sync = "!curr=$(git rev-parse --abbrev-ref HEAD) && git fetch --all && git submodule update --init --recursive && if git remote get-url upstream >/dev/null 2>&1; then git pull --ff-only upstream \"$curr\" && git push origin \"$curr\"; else git pull --ff-only; fi"


### PR DESCRIPTION
## Summary

- remove the unconditional `~/.gitconfig.local` include from the tracked WSL Git configuration

## Why

The dotfiles do not create or otherwise use `~/.gitconfig.local`, so including it suggests a supported customization path that does not exist elsewhere in the repository. Removing the include avoids that confusion.

## Impact

Installed Git configuration no longer attempts to include `~/.gitconfig.local`. All tracked global and conditional Git settings remain unchanged.

## Validation

- `git config --file wsl/home/.gitconfig --list`
- `git diff --check`
- repository pre-commit checks

## Summary by Sourcery

Enhancements:
- Stop including the nonexistent ~/.gitconfig.local file from the tracked WSL Git configuration to avoid implying an unsupported customization path.