### PR TITLE
fix(git): disable signing for UNSW repositories

### DIFF
--- a/wsl/home/.config/git/unsw.gitconfig
+++ b/wsl/home/.config/git/unsw.gitconfig
@@ -1,2 +1,7 @@
 [user]
 	email = 14969-z5642102@users.noreply.gitlab2.cse.unsw.edu.au
+
+[commit]
+	gpgSign = false
+[tag]
+	gpgSign = false


### PR DESCRIPTION
## Summary

- disable GPG signing for commits in the UNSW-specific Git configuration
- disable GPG signing for tags in the same scope

## Why

The UNSW Git configuration should override any globally enabled signing settings. This prevents UNSW Git operations from attempting to use the user's signing key while preserving signing behavior for other repositories.

## Impact

Repositories matched by the UNSW Git configuration will create unsigned commits and tags. Other repositories are unaffected.

## Validation

- parsed both settings with `git config --file ... --bool`
- ran `git diff --check`
- passed the repository pre-commit checks

## Summary by Sourcery

Adjust UNSW-specific Git configuration to ensure local settings override global signing behavior.

Enhancements:
- Disable GPG signing for commits within UNSW-scoped Git repositories.
- Disable GPG signing for tags within UNSW-scoped Git repositories.