### PR TITLE
refactor(hk): move worker checks to subproject

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -2,6 +2,8 @@ amends "https://raw.githubusercontent.com/risu729/hk-config/v1.1.0/presets.pkl"
 
 import "https://raw.githubusercontent.com/risu729/hk-config/v1.1.0/helpers.pkl"
 
+subprojects = List("worker")
+
 local const bashrcGlobs = List("wsl/home/.bashrc")
 
 local function includeBashrc(step: Step): Step = (step) {
@@ -31,27 +33,6 @@ local picked =
 
 local mise = picked["mise"] as Group
 
-local worker = new Group {
-  dir = "worker"
-  steps {
-    ["generate-types"] = new Step {
-      check = "bun run wrangler types src/worker-configuration.d.ts"
-      hide = true
-    }
-    ["tsc:base"] = (picked["tsc"]) {
-      workspace_indicator = "tsconfig.base.json"
-    }
-    ["tsc:src"] = (picked["tsc"]) {
-      workspace_indicator = "tsconfig.src.json"
-      depends = List("generate-types")
-    }
-    ["tsc:test"] = (picked["tsc"]) {
-      workspace_indicator = "tsconfig.test.json"
-      depends = List("generate-types")
-    }
-  }
-}
-
 hooks =
   helpers.standardHooks((picked) {
     ["shfmt"] = includeBashrc(picked["shfmt"] as Step)
@@ -79,5 +60,4 @@ hooks =
       check =
         "pwsh -NoProfile -Command 'Invoke-ScriptAnalyzer -Path win -Recurse -EnableExit -Settings win/PSScriptAnalyzerSettings.psd1'"
     }
-    ["worker"] = worker
   })

--- a/worker/hk.pkl
+++ b/worker/hk.pkl
@@ -1,0 +1,29 @@
+amends "https://raw.githubusercontent.com/risu729/hk-config/v1.1.0/presets.pkl"
+
+import "https://raw.githubusercontent.com/risu729/hk-config/v1.1.0/helpers.pkl"
+
+local tsc = helpers.pick(new Listing { "tsc" })["tsc"] as Step
+
+local steps = new Mapping<String, Step | Group> {
+  ["generate-types"] = new Step {
+    check = "bun run wrangler types src/worker-configuration.d.ts"
+    hide = true
+  }
+  ["tsc:base"] = (tsc) {
+    // The subproject fixes the working directory, so each check can target its config directly.
+    workspace_indicator = null
+    check = "tsc --noEmit -p tsconfig.base.json"
+  }
+  ["tsc:src"] = (tsc) {
+    workspace_indicator = null
+    depends = List("generate-types")
+    check = "tsc --noEmit -p tsconfig.src.json"
+  }
+  ["tsc:test"] = (tsc) {
+    workspace_indicator = null
+    depends = List("generate-types")
+    check = "tsc --noEmit -p tsconfig.test.json"
+  }
+}
+
+hooks = helpers.standardHooks(steps)


### PR DESCRIPTION
## Summary

- register `worker` as an hk subproject
- move worker type generation and TypeScript checks into `worker/hk.pkl`
- use the subproject working directory to target each worker tsconfig directly

## Why

hk 1.52.0 supports nested subproject configurations. Keeping these checks beside the Worker project removes the root `Group.dir` wrapper and lets hk provide directory scoping and prefixed step names.

## Validation

Validated after rebasing onto the released dependency updates (`hk` 1.52.0 and `hk-config` v1.1.0):

- `pkl format --diff-name-only hk.pkl worker/hk.pkl`
- `hk validate`
- `hk check --all --step worker:generate-types`
- `hk check --all --step worker:tsc:base`
- `hk check --all --step worker:tsc:src`
- `hk check --all --step worker:tsc:test`
- pre-commit hk checks