### PR TITLE
chore(hk): use hk-config release tag

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -1,8 +1,6 @@
-amends
-  "https://raw.githubusercontent.com/risu729/hk-config/a34802b174b5a1f669dbd09fb6301f7eca7a5770/presets.pkl"
+amends "https://raw.githubusercontent.com/risu729/hk-config/v1.1.0/presets.pkl"
 
-import
-  "https://raw.githubusercontent.com/risu729/hk-config/a34802b174b5a1f669dbd09fb6301f7eca7a5770/helpers.pkl"
+import "https://raw.githubusercontent.com/risu729/hk-config/v1.1.0/helpers.pkl"
 
 local const bashrcGlobs = List("wsl/home/.bashrc")
 


### PR DESCRIPTION
## Summary

- replace the temporary hk-config commit SHA with the released `v1.1.0` tag
- keep the preset and helper imports on the same version
- restore compatibility with the shared Renovate hk-config manager

## Why

The SHA was introduced before hk-config v1.1.0 was released so dotfiles could use the hk 1.51 schema. It remained after the release, and Renovate cannot detect it because the custom manager matches version-tag URLs.

## Impact

Dotfiles now consumes the published v1.1.0 catalog and future hk-config releases can be proposed by Renovate normally.

## Validation

- `pkl format --diff-name-only hk.pkl`
- `pkl eval hk.pkl`
- `hk validate`
- pre-commit hk checks

## Summary by Sourcery

Enhancements:
- Align hk presets and helper imports to the hk-config v1.1.0 release tag for consistent versioning across dotfiles.