### PR TITLE
chore(mise): allow immediate Claude releases

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -73,7 +73,7 @@ glow = "latest"
 # ai agents
 codex = { version = "latest", minimum_release_age = "0s" }
 "npm:ccusage" = "latest"
-claude = "latest"
+claude = { version = "latest", minimum_release_age = "0s" }
 copilot = "latest"
 
 # linter/formatter tools


### PR DESCRIPTION
## Summary

- override the global minimum release age for Claude
- allow `latest` Claude releases to resolve immediately

## Why

The global mise configuration normally delays new releases by three hours. Claude should be exempt from that delay, matching the existing Codex configuration.

## Validation

- `git diff --check`
- `mise x tombi -- tombi lint wsl/home/.config/mise/config.toml`
- repository pre-commit checks

## Summary by Sourcery

Enhancements:
- Configure Claude to use the latest version without any minimum release age delay in the mise config.