### PR TITLE
docs: correct Cloudflare token permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ The following command will lint and format the code, including auto-fixes:
 mise check
 ```
 
+### ☁️ Cloudflare Worker Deployment
+
+GitHub Actions reads repository variable `CLOUDFLARE_ACCOUNT_ID` and
+repository secret `CLOUDFLARE_API_TOKEN` to deploy the Worker. The token's
+minimum permissions are:
+
+- Account `risu`: `Workers Scripts: Edit`.
+- Zone `risunosu.com`: `Workers Routes: Read`.
+
+Wrangler reads the zone's Worker routes before publishing the configured Custom
+Domain to detect assignments to another Worker. Cloudflare creates the Custom
+Domain's DNS record and certificate, so `DNS: Edit` is not required. If the
+configuration later uses an ordinary route, replace `Workers Routes: Read`
+with `Workers Routes: Edit`.
+
 ## 📜 License
 
 MIT


### PR DESCRIPTION
## Summary

- document the GitHub variable and secret used for Worker deployment
- document the minimum Cloudflare token scopes
- distinguish Custom Domain permissions from ordinary-route permissions

## Why

Wrangler performs a Worker-route conflict preflight before publishing Dotfiles' Custom Domain. The deployment therefore needs Account `risu` / Workers Scripts / Edit and Zone `risunosu.com` / Workers Routes / Read.

Custom Domains do not require DNS / Edit. An ordinary route would instead require Workers Routes / Edit.

This repository does not currently have an `AGENTS.md`, so the deployment guidance lives in its README.

## Validation

- `mise run check --lint`