### PR TITLE
feat: enable Workers logs and traces

### DIFF
--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -10,7 +10,12 @@
 	"main": "src/index.ts",
 	"name": "dotfiles-worker",
 	"observability": {
-		"enabled": true,
+		"logs": {
+			"enabled": true,
+		},
+		"traces": {
+			"enabled": true,
+		},
 	},
 	"placement": {
 		"mode": "smart",
@@ -20,7 +25,7 @@
 		"custom_domain": true,
 		"pattern": "dot.risunosu.com",
 	},
-	"send_metrics": true,
+	"upload_source_maps": true,
 	// disable *.worker.dev domain
 	"workers_dev": false,
 }


### PR DESCRIPTION
## Summary

- enable persisted Workers Logs explicitly
- enable automatic Workers Tracing
- upload source maps for readable Worker exception stacks
- remove the redundant `send_metrics: true` default

## Why

`observability.enabled = true` currently enables logs but not automatic tracing. Defining both nested settings enables the full included observability configuration.

Sampling settings are intentionally omitted because Cloudflare defaults them to the maximum rate of `1` (100%). Wrangler telemetry already defaults `send_metrics` to true, so the explicit setting did not change behavior.

No paid Logpush, Tail Worker, or OpenTelemetry destination is configured.

## Impact

Production deployments will persist logs, automatically instrument traces, and upload source maps. Trace spans and log events consume the account's included observability allowance.

## Validation

- `mise run check --lint`
- `CI=true mise run worker:test` (18 tests)
- Wrangler 4.112 dry-run

## Summary by Sourcery

Enable full Cloudflare Workers observability configuration by turning on persisted logs, automatic tracing, and source map uploads while cleaning up redundant telemetry settings.

New Features:
- Enable persisted Workers logs for production deployments.
- Enable automatic Workers tracing for deployed Workers.
- Upload source maps to improve readability of Worker exception stack traces.

Enhancements:
- Remove redundant explicit send_metrics default now covered by Wrangler telemetry.