### PR TITLE
chore: add Herdr config

### DIFF
--- a/wsl/home/.config/herdr/config.toml
+++ b/wsl/home/.config/herdr/config.toml
@@ -1,0 +1,10 @@
+[ui]
+show_agent_labels_on_pane_borders = true
+agent_panel_sort = "spaces"
+
+[ui.toast]
+delivery = "herdr"
+
+[theme]
+name = "catppuccin-latte"
+auto_switch = false


### PR DESCRIPTION
## Summary

- add the current Herdr UI configuration to the WSL dotfiles
- enable in-app Herdr toast notifications
- show detected agent labels on pane borders
- keep the agent panel grouped by workspace
- use the Catppuccin Latte theme without automatic theme switching

## Why

Herdr is now the persistent agent workspace manager in this environment. Keeping its intentional UI preferences under dotfile management makes new and restored WSL environments reproduce the same Herdr experience without committing Herdr's full commented default configuration.

## Impact

The existing `symlink-each` mapping for `~/.config` installs this file as `~/.config/herdr/config.toml`. Defaults not listed in the file continue to follow the installed Herdr version.

## Validation

- Herdr 0.7.5 config reload with no diagnostics
- `tombi lint --error-on-warnings wsl/home/.config/herdr/config.toml`
- `mise run check --lint`
- commit hooks

## Summary by Sourcery

Add a Herdr UI configuration file to the WSL dotfiles so Herdr instances inherit consistent UI and theme preferences.

Enhancements:
- Configure Herdr UI to show agent labels on pane borders and keep the agent panel grouped by workspace.
- Enable in-app Herdr toast notifications via the Herdr delivery channel.
- Set the Herdr theme to Catppuccin Latte with automatic theme switching disabled.

Chores:
- Check in the Herdr config.toml under wsl/home/.config/herdr to be managed with the existing dotfiles symlink setup.