### PR TITLE
chore: install Herdr integrations during bootstrap

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -99,6 +99,10 @@ for agent in universal claude-code; do
   mise exec -- gh skill install mattpocock/skills skills/productivity/grilling \
     --agent "${agent}" --scope user --pin main --force
 done
+
+for integration in claude codex; do
+  mise exec -- herdr integration install "${integration}"
+done
 '''
 
 [bootstrap.hooks.final]


### PR DESCRIPTION
## Summary

- install the Claude and Codex Herdr integrations in the post-tools bootstrap hook
- rely on the existing dotfile mappings to create both agent configuration directories

## Why

Herdr integration hooks are generated files outside the tracked Herdr configuration, so a fresh dotfiles bootstrap did not recreate them. Installing them after tools are available keeps the generated hooks current with the installed Herdr version.

## Impact

Running `mise bootstrap` now configures native Herdr session integration for Claude Code and Codex. Copilot is intentionally excluded.

## Validation

- `git diff --check`
- `mise run check`

## Summary by Sourcery

Install Herdr integrations as part of the bootstrap process so editor integrations are kept in sync with the installed Herdr version.

New Features:
- Automatically install Claude and Codex Herdr integrations during the post-tools bootstrap hook.

Enhancements:
- Leverage existing dotfile mappings to ensure Herdr agent configuration directories are created during bootstrap.