### PR TITLE
docs: require publishing repository changes

### DIFF
--- a/wsl/home/.codex/AGENTS.md
+++ b/wsl/home/.codex/AGENTS.md
@@ -12,6 +12,9 @@ instructions take precedence.
 
 ## Commits and Pull Requests
 
+- After making repository changes, always commit and push them. Update an
+  existing PR if one exists; otherwise open a PR. Only leave changes local when
+  explicitly requested.
 - Follow repository conventions for commits and PR titles.
 - When the target repository is not owned by the user, create a draft PR by
   default. Never mark it ready for review unless explicitly asked.


### PR DESCRIPTION
## Summary

- require agents to commit and push after making repository changes
- require agents to update an existing PR or open a new one
- allow local-only changes only when explicitly requested

## Why

Agents sometimes stopped after making local changes, even when asked to fix repository code. This makes publishing the default completion behavior for both Codex and Claude Code because they share this instruction file.

## Validation

- `mise run check --lint`
- commit hooks

## Summary by Sourcery

Documentation:
- Update agent instructions to require committing, pushing, and opening or updating pull requests after repository modifications, with local-only changes allowed only when explicitly requested.