### PR TITLE
fix(wsl): install mise through extrepo

### DIFF
--- a/wsl/install.sh
+++ b/wsl/install.sh
@@ -19,9 +19,13 @@ log_error() {
 }
 
 install_mise() {
-	log_info "Adding mise PPA..."
+	log_info "Installing extrepo..."
 	# ref: https://mise.jdx.dev/installing-mise.html#apt
-	sudo add-apt-repository --yes --no-update ppa:jdxcode/mise
+	sudo apt-get update
+	sudo apt-get install --yes extrepo
+
+	log_info "Adding mise APT repository..."
+	sudo extrepo enable mise
 
 	log_info "Installing mise..."
 	sudo apt-get update


### PR DESCRIPTION
## Summary

- replace the Launchpad mise PPA bootstrap with the officially documented `extrepo` setup
- keep mise managed by APT while sourcing it from mise's own Debian repository

## Why

The Launchpad PPA can lag behind GitHub releases. Renovate raised the required mise version to 2026.7.12 while the PPA still served 2026.7.11, causing the WSL installer CI job to fail. The repository enabled by `extrepo` already serves 2026.7.12.

## Impact

Fresh WSL installations add mise's APT repository through `extrepo` and then install mise normally with `apt-get`.

## Validation

- `bash -n wsl/install.sh`
- `mise run check --lint`
- Ubuntu 26.04 container smoke test: installed `extrepo`, enabled mise, refreshed APT metadata, and confirmed mise 2026.7.12 as the candidate

## Summary by Sourcery

Update WSL mise installation to use the official extrepo-based APT repository instead of the Launchpad PPA.

Bug Fixes:
- Resolve WSL installer failures caused by mismatched mise versions between the Launchpad PPA and the required version.

Enhancements:
- Align mise installation on WSL with the officially documented extrepo-based Debian/Ubuntu setup.