### PR TITLE
chore: save Codex config seed

### DIFF
--- a/wsl/home/.codex/config.seed.toml
+++ b/wsl/home/.codex/config.seed.toml
@@ -1,0 +1,29 @@
+# Safe, durable preferences to merge into ~/.codex/config.toml.
+# Keep the live config untracked because Codex also writes generated state and secrets there.
+
+model_reasoning_effort = "high"
+plan_mode_reasoning_effort = "xhigh"
+
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+
+# Explicitly use standard speed instead of the Fast/priority service tier.
+service_tier = "default"
+
+[tui]
+status_line = [
+	"model-with-reasoning",
+	"context-remaining",
+	"pull-request-number",
+	"five-hour-limit",
+	"weekly-limit",
+]
+
+[features]
+prevent_idle_sleep = true
+
+[mcp_servers.cloudflare-docs]
+url = "https://docs.mcp.cloudflare.com/mcp"
+
+[mcp_servers.cloudflare-api]
+url = "https://mcp.cloudflare.com/mcp"


### PR DESCRIPTION
## Summary

- add a tracked `wsl/home/.codex/config.seed.toml` containing the current safe, non-default Codex preferences
- retain reasoning, permission, service-tier, status-line, idle-sleep, and Cloudflare MCP settings
- keep the live `~/.codex/config.toml` untracked so generated state and literal OTEL credentials cannot enter the repository

## Why

Codex currently stores durable preferences alongside project trust, hook hashes, UI state, connector state, and OTEL credentials. Tracking or symlinking the live file would both dirty the repository and risk committing secrets.

This seed is the safe canonical input for a future merge/install step tracked in #3833.

## Validation

- `tombi lint wsl/home/.codex/config.seed.toml`
- `tombi format --check wsl/home/.codex/config.seed.toml`
- repository pre-commit hooks, including `betterleaks`
- parsed the seed as TOML and compared its selected values with the live configuration

Related to #3833.

## Summary by Sourcery

Enhancements:
- Define a canonical Codex config seed with reasoning effort, sandbox/approval policy, service tier, TUI status line, idle-sleep, and Cloudflare MCP settings while keeping the live config untracked.