### PR TITLE
chore: prioritize Herdr agents

### DIFF
--- a/wsl/home/.config/herdr/config.toml
+++ b/wsl/home/.config/herdr/config.toml
@@ -1,9 +1,6 @@
 [ui]
 show_agent_labels_on_pane_borders = true
-agent_panel_sort = "spaces"
-
-[ui.toast]
-delivery = "herdr"
+agent_panel_sort = "priority"
 
 [theme]
 name = "catppuccin-latte"


### PR DESCRIPTION
## Summary

- sort Herdr's Agents panel as an attention queue instead of grouping agents by Space
- remove the explicit toast delivery setting because `off` is Herdr's default

## Why

The live Herdr UI persisted two preference changes. Priority ordering is a meaningful override, while tracking `delivery = "off"` would duplicate the application default. Keeping only the non-default value makes the dotfiles configuration minimal and easier to maintain.

## Impact

Blocked agents appear first, followed by unseen completed agents, working agents, seen idle agents, and unknown agents. Popup notifications remain disabled through Herdr's default behavior.

## Validation

- `herdr config check`
- `tombi lint wsl/home/.config/herdr/config.toml`
- `tombi format --check wsl/home/.config/herdr/config.toml`
- repository pre-commit hooks, including `betterleaks`