### PR TITLE
chore: disable SSH agent for Tamia

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -167,6 +167,7 @@ login_shell = "/bin/bash"
 "~/.hushlogin" = "wsl/home/.hushlogin"
 "~/.local" = { source = "wsl/home/.local", mode = "symlink-each" }
 "~/.selected_editor" = "wsl/home/.selected_editor"
+"~/.ssh/config" = "wsl/home/.ssh/config"
 
 [hooks]
 postinstall = """

--- a/wsl/home/.ssh/config
+++ b/wsl/home/.ssh/config
@@ -1,0 +1,6 @@
+Host tamia.internal.risunosu.com
+  User risu
+  IdentityAgent none
+  IdentitiesOnly yes
+  PasswordAuthentication no
+  KbdInteractiveAuthentication no


### PR DESCRIPTION
## Summary

- add a host-specific OpenSSH configuration for Tamia
- disable SSH agent use and password/keyboard-interactive fallbacks
- install the SSH config through the existing mise dotfiles mapping

## Why

Tamia is accessed keylessly over Cloudflare WARP, so the client should not offer credentials from the local SSH agent or fall back to interactive authentication.

## Validation

- `ssh -G -F wsl/home/.ssh/config tamia.internal.risunosu.com`
- `mise run check --lint`

## Summary by Sourcery

Add host-specific SSH configuration for Tamia and manage it via the existing mise dotfiles mapping.

Enhancements:
- Manage ~/.ssh/config via mise by mapping it to the WSL dotfiles directory for Tamia-specific configuration.

Chores:
- Introduce a dedicated SSH config file for Tamia that disables SSH agent and interactive authentication in line with keyless Cloudflare WARP access.