### PR TITLE
fix(worker): deploy Vite build output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           mode: ${{ github.event_name == 'pull_request' && 'preview-or-dry-run' || 'dry-run' }}
           working-directory: worker
-          config: wrangler.jsonc
+          config: dist/dotfiles_worker/wrangler.json
           preview-alias: pr-${{ github.event.pull_request.number }}
           cloudflare-account-id: ${{ github.event_name == 'pull_request' && vars.CLOUDFLARE_ACCOUNT_ID || '' }}
           cloudflare-api-token: ${{ github.event_name == 'pull_request' && secrets.CLOUDFLARE_API_TOKEN || '' }}

--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -44,6 +44,6 @@ jobs:
         with:
           mode: production
           working-directory: worker
-          config: wrangler.jsonc
+          config: dist/dotfiles_worker/wrangler.json
           cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

- deploy the Vite-generated Wrangler configuration in production
- use the same generated configuration for PR previews and CI dry runs

## Root cause

The deploy workflows built the Worker with Vite but passed the source `worker/wrangler.jsonc` to `wrangler-deploy-action`. That configuration points to `src/index.ts`, so Wrangler rebundled and deployed the source instead of Vite's output. The resulting production bundle retained Vite-only `import.meta.env` references and threw at runtime on `/win` and `/wsl`.

## Impact

Installer routes deploy the compiled Worker bundle, where Vite has replaced `DEFAULT_BRANCH` and removed the development-only `GITHUB_TOKEN` access. The root redirect and installer behavior otherwise remain unchanged.

## Validation

- `mise run worker:build`
- confirmed `worker/dist/dotfiles_worker/index.js` contains no `import.meta.env` references
- `bun run wrangler deploy --config dist/dotfiles_worker/wrangler.json --dry-run`
- `CI=true mise run worker:test` (18 tests passed)
- `mise run check --lint`

## Summary by Sourcery

Ensure Cloudflare Worker deployments use the Vite-generated Wrangler configuration instead of the source config.

Bug Fixes:
- Prevent production Worker bundle from deploying uncompiled source that still references import.meta.env.

CI:
- Update CI dry-run and PR preview workflows to deploy using dist/dotfiles_worker/wrangler.json.

Deployment:
- Update production worker deployment workflow to use the built Wrangler config from dist/dotfiles_worker/wrangler.json.