### PR TITLE
docs: require hk for linting

### DIFF
--- a/wsl/home/.codex/AGENTS.md
+++ b/wsl/home/.codex/AGENTS.md
@@ -34,4 +34,6 @@ that PR automatically. Ask only when multiple source PRs are plausible.
 
 ## Tooling
 
+- Use `hk` when configured; never invoke linters directly, as `hk` may supply
+  custom defaults such as CLI arguments.
 - Use `mise x` for one-off tools that mise does not already resolve.


### PR DESCRIPTION
## Summary

- require agents to use `hk` when it is configured
- prohibit direct linter invocation so project-specific defaults, including CLI arguments, are preserved

## Validation

- `hk check wsl/home/.codex/AGENTS.md`

## Summary by Sourcery

Documentation:
- Update AGENTS guide to instruct agents to run linters via hk when available and not call linters directly.