### PR TITLE
chore: add tamia SSH alias

### DIFF
--- a/wsl/home/.ssh/config
+++ b/wsl/home/.ssh/config
@@ -1,4 +1,5 @@
-Host tamia.internal.risunosu.com
+Host tamia tamia.internal.risunosu.com
+  HostName tamia.internal.risunosu.com
   User risu
   IdentityAgent none
   IdentitiesOnly yes


### PR DESCRIPTION
## Summary

- add `tamia` as a short alias for `tamia.internal.risunosu.com`
- set the canonical hostname explicitly with `HostName`
- retain the full hostname as a valid SSH host pattern

## Why

The existing SSH configuration matched only the full hostname, so `ssh tamia` did not apply the configured user and authentication settings or resolve to the internal hostname.

## Impact

Both `ssh tamia` and `ssh tamia.internal.risunosu.com` now connect to the same host using the existing SSH settings.

## Validation

- `ssh -G tamia` resolves to user `risu` and hostname `tamia.internal.risunosu.com`
- `hk check wsl/home/.ssh/config`

## Summary by Sourcery

Chores:
- Update WSL SSH configuration so `ssh tamia` and `ssh tamia.internal.risunosu.com` use the same user and host settings.