### PR TITLE
docs: clarify PR readiness defaults

### DIFF
--- a/wsl/home/.codex/AGENTS.md
+++ b/wsl/home/.codex/AGENTS.md
@@ -16,6 +16,9 @@ instructions take precedence.
   existing PR if one exists; otherwise open a PR. Only leave changes local when
   explicitly requested.
 - Follow repository conventions for commits and PR titles.
+- When the target repository is owned by the user, mark small, low-risk PRs
+  ready for review by default. Use a draft for larger, unfinished, or uncertain
+  changes.
 - When the target repository is not owned by the user, create a draft PR by
   default. Never mark it ready for review unless explicitly asked.
 - Do not add AI-authorship notices or tool signatures unless required.


### PR DESCRIPTION
## Summary

- make small, low-risk PRs in user-owned repositories ready for review by default
- retain drafts for larger, unfinished, or uncertain changes
- retain the draft-only default for repositories not owned by the user

## Why

The previous wording defined the default for externally owned repositories but left user-owned repositories ambiguous, allowing a generic publishing workflow to create unnecessary draft PRs.

## Impact

Agents now have an explicit readiness policy based on repository ownership and change risk.

## Validation

- `hk check wsl/home/.codex/AGENTS.md`
- `git diff --check`

## Summary by Sourcery

Documentation:
- Update AGENTS.md to specify that small, low-risk PRs in user-owned repositories should be ready for review by default while larger or uncertain changes remain drafts, and external repositories stay draft-only by default.