### PR TITLE
chore: add bots SSH alias

### DIFF
--- a/wsl/home/.ssh/config
+++ b/wsl/home/.ssh/config
@@ -5,3 +5,11 @@ Host tamia tamia.internal.risunosu.com
   IdentitiesOnly yes
   PasswordAuthentication no
   KbdInteractiveAuthentication no
+
+Host bots bots.internal.risunosu.com
+  HostName bots.internal.risunosu.com
+  User ubuntu
+  IdentityAgent none
+  IdentitiesOnly yes
+  PasswordAuthentication no
+  KbdInteractiveAuthentication no


### PR DESCRIPTION
## Summary

- add `bots` as a short alias for `bots.internal.risunosu.com`
- configure SSH to connect as `ubuntu`
- mirror the keyless/no-agent authentication settings used by `tamia`

## Why

Cloudflare DNS identifies `bots.internal.risunosu.com` as the WARP private SSH endpoint, while `bots.risunosu.com` is the proxied browser-SSH tunnel. The local SSH config did not yet provide a short alias for the private endpoint.

## Impact

`ssh bots` connects to `bots.internal.risunosu.com` as `ubuntu` with passwords and keyboard-interactive authentication disabled.

## Validation

- Cloudflare DNS: `bots.internal.risunosu.com` resolves to private address `10.0.1.120`
- `ssh -G bots` resolves to user `ubuntu` and hostname `bots.internal.risunosu.com`
- `hk check wsl/home/.ssh/config`

## Summary by Sourcery

Enhancements:
- Configure the bots SSH alias to connect as the ubuntu user with password and keyboard-interactive authentication disabled.