### PR TITLE
chore(pitchfork): enable system boot and reverse proxy

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -62,7 +62,7 @@ kubectx = "latest"
 kubeseal = "latest"
 mitmproxy = "latest"
 doggo = "latest"
-pitchfork = { version = "latest", postinstall = "pitchfork boot disable || true; pitchfork boot enable" }
+pitchfork = { version = "latest", postinstall = "pitchfork boot disable || true; sudo \"$(mise which pitchfork)\" boot disable || true; sudo \"$(mise which pitchfork)\" boot enable" }
 miller = "latest"
 glow = "latest"
 "github:garden-rs/garden" = "latest"

--- a/wsl/home/.config/pitchfork/config.toml
+++ b/wsl/home/.config/pitchfork/config.toml
@@ -3,8 +3,6 @@
 [settings]
 general.mise = true
 web.auto_start = true
-# System-level boot (`sudo pitchfork boot enable`) runs the supervisor as root
-# so the reverse proxy can bind :443. Keep state, IPC, and daemons under this user.
 supervisor.user = "risu"
 
 [settings.proxy]

--- a/wsl/home/.config/pitchfork/config.toml
+++ b/wsl/home/.config/pitchfork/config.toml
@@ -3,5 +3,11 @@
 [settings]
 general.mise = true
 web.auto_start = true
+# System-level boot (`sudo pitchfork boot enable`) runs the supervisor as root
+# so the reverse proxy can bind :443. Keep state, IPC, and daemons under this user.
+supervisor.user = "risu"
+
+[settings.proxy]
+enable = true
 
 [daemons]


### PR DESCRIPTION
## Summary

- Enable pitchfork's reverse proxy in the global config so daemons can use stable HTTPS URLs (default `https://<slug>.localhost` on port 443).
- Run the supervisor via **system-level** boot (`sudo … boot enable`) while keeping the binary from **user mise** (no `mise install --system`).
- Set `supervisor.user = "risu"` so root-started supervisor still keeps state, IPC sockets, and daemon processes under the normal user.

## Why

Privileged proxy ports (443) need the supervisor to bind as root. User-level systemd cannot do that. System-level boot fixes binding, but without `supervisor.user` state/IPC would land under root and break the usual CLI/TUI/web workflow.

User mise remains the install source: `boot enable` bakes the absolute path from `mise which pitchfork` into the unit. Passwordless sudo (already in this repo's bootstrap) makes the postinstall non-interactive.

## Changes

### `wsl/home/.config/pitchfork/config.toml`

- `supervisor.user = "risu"` — daemons/state/IPC stay owned by the login user when the supervisor runs as root.
- `[settings.proxy] enable = true` — turn on the built-in reverse proxy (HTTPS + port 443 defaults). Slugs are still added separately with `pitchfork proxy add …`.

### `wsl/home/.config/mise/config.toml`

Update pitchfork `postinstall` to migrate boot registration to system level on every upgrade:

```bash
pitchfork boot disable || true
sudo "$(mise which pitchfork)" boot disable || true
sudo "$(mise which pitchfork)" boot enable
```

This clears any leftover user unit, then registers `/etc/systemd/system/pitchfork.service` pointing at the current mise-installed binary.

## Explicitly not doing

- **No `mise install --system`** — root can execute the user mise binary; system install only relocates the file and does not remove the need to re-run `boot enable` after upgrades.
- **No mise shim in `ExecStart`** — shims resolve to `mise` itself; `boot enable` also `canonicalize()`s paths, so shims are unsuitable for the unit.
- **No project slugs in this PR** — proxy is enabled globally; per-project slugs (e.g. biwa docs) can be added later with `pitchfork proxy add`.

## Apply on this machine after merge

```bash
# pick up config (symlink already points at dotfiles)
mise install pitchfork   # runs postinstall → system boot enable
# or one-shot without reinstall:
pitchfork boot disable || true
sudo "$(mise which pitchfork)" boot disable || true
sudo "$(mise which pitchfork)" boot enable
sudo systemctl restart pitchfork
pitchfork boot status
pitchfork proxy status
```

## Test plan

- [ ] `sudo -n true` still works (passwordless sudo required for postinstall)
- [ ] After install/postinstall: `pitchfork boot status` shows system-level enabled; `~/.config/systemd/user/pitchfork.service` is gone or disabled; `/etc/systemd/system/pitchfork.service` exists and `ExecStart` points at the current mise pitchfork path
- [ ] `pitchfork supervisor status` / `pitchfork list` work as user (IPC under `~/.local/state/pitchfork` via `supervisor.user`)
- [ ] Proxy listens on 443; `pitchfork proxy status` reports enabled
- [ ] Web UI still comes up (`web.auto_start`); `http://127.0.0.1:3120/` responds
- [ ] Upgrading pitchfork via mise re-runs postinstall and refreshes the system unit path


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Enable pitchfork to run via system-level boot while keeping daemon state under the normal user and turning on the built-in HTTPS reverse proxy.

New Features:
- Enable pitchfork's reverse proxy in the global config to provide stable HTTPS URLs on port 443 for daemons.

Enhancements:
- Configure the pitchfork supervisor to run as root but keep state and IPC owned by the login user via supervisor.user.
- Update the mise pitchfork postinstall script to migrate boot registration to a system-level service using the currently installed binary.