### PR TITLE
chore(pitchfork): run supervisor non-root via systemd drop-in

### DIFF
--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -66,7 +66,6 @@ pitchfork = { version = "latest", postinstall = """
 src="$(dirname "$(readlink -f ~/.config/mise/config.toml)")/../../../systemd/pitchfork-nonroot.conf"
 sudo "$MISE_TOOL_INSTALL_PATH/pitchfork" boot disable
 sudo "$MISE_TOOL_INSTALL_PATH/pitchfork" boot enable
-sudo rm -rf /etc/systemd/system/pitchfork.service.d
 sudo install -D -m644 "$src" /etc/systemd/system/pitchfork.service.d/nonroot.conf
 sudo systemctl daemon-reload
 sudo systemctl restart pitchfork.service

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -65,8 +65,7 @@ doggo = "latest"
 pitchfork = { version = "latest", postinstall = """
 cfg=$(readlink -f ~/.config/mise/config.toml)
 root=$(git -C "$(dirname "$cfg")" rev-parse --show-toplevel)
-pf=$(mise which pitchfork)
-pitchfork boot disable >/dev/null 2>&1 || true
+pf="$MISE_TOOL_INSTALL_PATH/pitchfork"
 sudo "$pf" boot disable >/dev/null 2>&1 || true
 sudo "$pf" boot enable
 sudo rm -rf /etc/systemd/system/pitchfork.service.d

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -62,7 +62,18 @@ kubectx = "latest"
 kubeseal = "latest"
 mitmproxy = "latest"
 doggo = "latest"
-pitchfork = { version = "latest", postinstall = "pitchfork boot disable || true; sudo \"$(mise which pitchfork)\" boot disable || true; sudo \"$(mise which pitchfork)\" boot enable" }
+pitchfork = { version = "latest", postinstall = """
+cfg=$(readlink -f ~/.config/mise/config.toml)
+root=$(git -C "$(dirname "$cfg")" rev-parse --show-toplevel)
+pf=$(mise which pitchfork)
+pitchfork boot disable >/dev/null 2>&1 || true
+sudo "$pf" boot disable >/dev/null 2>&1 || true
+sudo "$pf" boot enable
+sudo rm -rf /etc/systemd/system/pitchfork.service.d
+sudo install -D -m644 "$root/wsl/systemd/pitchfork-nonroot.conf" /etc/systemd/system/pitchfork.service.d/nonroot.conf
+sudo systemctl daemon-reload
+sudo systemctl restart pitchfork.service
+""" }
 miller = "latest"
 glow = "latest"
 "github:garden-rs/garden" = "latest"

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -67,7 +67,9 @@ src="$(dirname "$(readlink -f ~/.config/mise/config.toml)")/../../../systemd/pit
 sudo install -D -m644 "$src" /etc/systemd/system/pitchfork.service.d/nonroot.conf
 sudo "$MISE_TOOL_INSTALL_PATH/pitchfork" boot disable
 sudo "$MISE_TOOL_INSTALL_PATH/pitchfork" boot enable
-sudo systemctl restart pitchfork.service
+if [ -d /run/systemd/system ]; then
+  sudo systemctl restart pitchfork.service
+fi
 """ }
 miller = "latest"
 glow = "latest"

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -64,10 +64,9 @@ mitmproxy = "latest"
 doggo = "latest"
 pitchfork = { version = "latest", postinstall = """
 src="$(dirname "$(readlink -f ~/.config/mise/config.toml)")/../../../systemd/pitchfork-nonroot.conf"
+sudo install -D -m644 "$src" /etc/systemd/system/pitchfork.service.d/nonroot.conf
 sudo "$MISE_TOOL_INSTALL_PATH/pitchfork" boot disable
 sudo "$MISE_TOOL_INSTALL_PATH/pitchfork" boot enable
-sudo install -D -m644 "$src" /etc/systemd/system/pitchfork.service.d/nonroot.conf
-sudo systemctl daemon-reload
 sudo systemctl restart pitchfork.service
 """ }
 miller = "latest"

--- a/wsl/home/.config/mise/config.toml
+++ b/wsl/home/.config/mise/config.toml
@@ -63,13 +63,11 @@ kubeseal = "latest"
 mitmproxy = "latest"
 doggo = "latest"
 pitchfork = { version = "latest", postinstall = """
-cfg=$(readlink -f ~/.config/mise/config.toml)
-root=$(git -C "$(dirname "$cfg")" rev-parse --show-toplevel)
-pf="$MISE_TOOL_INSTALL_PATH/pitchfork"
-sudo "$pf" boot disable >/dev/null 2>&1 || true
-sudo "$pf" boot enable
+src="$(dirname "$(readlink -f ~/.config/mise/config.toml)")/../../../systemd/pitchfork-nonroot.conf"
+sudo "$MISE_TOOL_INSTALL_PATH/pitchfork" boot disable
+sudo "$MISE_TOOL_INSTALL_PATH/pitchfork" boot enable
 sudo rm -rf /etc/systemd/system/pitchfork.service.d
-sudo install -D -m644 "$root/wsl/systemd/pitchfork-nonroot.conf" /etc/systemd/system/pitchfork.service.d/nonroot.conf
+sudo install -D -m644 "$src" /etc/systemd/system/pitchfork.service.d/nonroot.conf
 sudo systemctl daemon-reload
 sudo systemctl restart pitchfork.service
 """ }

--- a/wsl/systemd/pitchfork-nonroot.conf
+++ b/wsl/systemd/pitchfork-nonroot.conf
@@ -1,0 +1,6 @@
+[Service]
+User=risu
+Group=risu
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true

--- a/wsl/systemd/pitchfork-nonroot.conf
+++ b/wsl/systemd/pitchfork-nonroot.conf
@@ -1,6 +1,3 @@
 [Service]
 User=risu
-Group=risu
 AmbientCapabilities=CAP_NET_BIND_SERVICE
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-NoNewPrivileges=true


### PR DESCRIPTION
## Summary

- Keep pitchfork's autogen system unit (`sudo pitchfork boot enable`).
- Overlay a drop-in so the supervisor runs as `User=risu` with `CAP_NET_BIND_SERVICE`, binding `:443` without `HOME=/root`.

## Why

`sudo pitchfork boot enable` starts the supervisor as root with `HOME=/root`, so `~/.config/pitchfork/config.toml` is ignored. Related: [jdx/pitchfork#422](https://github.com/jdx/pitchfork/discussions/422). Dotfiles-only workaround; no upstream change.

## Changes

- `wsl/systemd/pitchfork-nonroot.conf` — drop-in source (`User=risu`, caps); installed to `/etc/systemd/system/pitchfork.service.d/nonroot.conf`
- pitchfork mise `postinstall` — `boot enable`, install the drop-in, restart

## Apply

```bash
git sm && git sync
mise bootstrap dotfiles apply -y
mise install pitchfork   # runs postinstall
```

## Test plan

- [ ] `systemctl cat pitchfork.service` shows autogen unit + `nonroot.conf`
- [ ] Supervisor runs as `risu` with `cap_net_bind_service`
- [ ] `:443` and `:3120` listen; user config (`proxy.enable`, `web.auto_start`) applies
- [ ] Re-running `sudo pitchfork boot enable` keeps the drop-in