### PR TITLE
chore: add cf-bastion SSH alias

### DIFF
--- a/wsl/home/.ssh/config
+++ b/wsl/home/.ssh/config
@@ -13,3 +13,11 @@ Host bots bots.internal.risunosu.com
   IdentitiesOnly yes
   PasswordAuthentication no
   KbdInteractiveAuthentication no
+
+Host cf-bastion cf-bastion.internal.risunosu.com
+  HostName cf-bastion.internal.risunosu.com
+  User ubuntu
+  IdentityAgent none
+  IdentitiesOnly yes
+  PasswordAuthentication no
+  KbdInteractiveAuthentication no


### PR DESCRIPTION
## Summary

- add `cf-bastion` and `cf-bastion.internal.risunosu.com` SSH host names
- map both names to the internal bastion hostname
- disable agent, password, and keyboard-interactive authentication consistently with the other internal hosts

## Impact

The Cloudflare bastion can be reached with either `ssh cf-bastion` or its fully qualified internal hostname using the repository-managed SSH configuration.

## Validation

- `hk check wsl/home/.ssh/config`
- verified both host names with `ssh -G -F wsl/home/.ssh/config`

## Summary by Sourcery

Add SSH configuration entries for the Cloudflare bastion host.

New Features:
- Introduce SSH host aliases `cf-bastion` and `cf-bastion.internal.risunosu.com` mapped to the internal bastion hostname.

Enhancements:
- Align authentication settings for the Cloudflare bastion with other internal hosts by disabling agent, password, and keyboard-interactive authentication.