### PR TITLE
chore: add CSE SSH alias

### DIFF
--- a/wsl/home/.ssh/config
+++ b/wsl/home/.ssh/config
@@ -21,3 +21,10 @@ Host cf-bastion cf-bastion.internal.risunosu.com
   IdentitiesOnly yes
   PasswordAuthentication no
   KbdInteractiveAuthentication no
+
+Host cse login.cse.unsw.edu.au
+  HostName login.cse.unsw.edu.au
+  User z5642102
+  PreferredAuthentications publickey
+  PasswordAuthentication no
+  KbdInteractiveAuthentication no


### PR DESCRIPTION
## Summary

- add `cse` and `login.cse.unsw.edu.au` SSH host names
- configure the UNSW zID and canonical login hostname
- require public-key authentication and disable password and keyboard-interactive authentication

## Impact

UNSW CSE can be reached with `ssh cse` using the Bitwarden-backed SSH agent key.

## Validation

- `hk check wsl/home/.ssh/config`
- `ssh -o BatchMode=yes -o PasswordAuthentication=no -o KbdInteractiveAuthentication=no cse 'printf key-auth-ok'`

## Summary by Sourcery

Configure SSH aliases for UNSW CSE login using key-based authentication only.

Enhancements:
- Add SSH host aliases for `cse` and `login.cse.unsw.edu.au` pointing to the UNSW CSE login service.
- Configure canonical UNSW zID-based login settings for the CSE SSH host.
- Enforce public-key-only authentication by disabling password and keyboard-interactive methods for the CSE SSH host.