### PR TITLE
chore: add Biwa config

### DIFF
--- a/wsl/home/.config/biwa/config.toml
+++ b/wsl/home/.config/biwa/config.toml
@@ -1,0 +1,5 @@
+#:schema https://biwa.takuk.me/schema/config.json
+
+[ssh]
+host = "login.cse.unsw.edu.au"
+user = "z5642102"


### PR DESCRIPTION
## Summary

- add the global Biwa configuration under `$XDG_CONFIG_HOME/biwa/config.toml`
- configure the UNSW CSE login host and zID
- rely on SSH key authentication without storing a password

## Impact

Biwa uses the dotfiles-managed XDG configuration to connect to `login.cse.unsw.edu.au` as `z5642102`. Authentication falls through to the Bitwarden-backed SSH agent after an unrelated default key is rejected.

## Dependency

Depends on risu729/biwa#952 for default-key-to-agent authentication fallback. Keep this PR draft until that change is available in the installed Biwa release.

## Validation

- `hk check wsl/home/.config/biwa/config.toml`
- confirmed the legacy plaintext `~/biwa.toml` is absent
- loaded the XDG config with the Biwa #952 build
- connected to CSE through the Bitwarden-backed agent and ran `true` with `--skip-sync`

## Summary by Sourcery

New Features:
- Introduce a Biwa config.toml under the XDG config directory to define SSH connection settings for UNSW CSE.