### PR TITLE
chore(pitchfork): proxy biwa docs under biwa.localhost

### DIFF
--- a/wsl/home/.config/pitchfork/config.toml
+++ b/wsl/home/.config/pitchfork/config.toml
@@ -1,4 +1,5 @@
 #:schema https://pitchfork.jdx.dev/schema.json
+#:tombi schema.strict = false
 
 [settings]
 general.mise = true
@@ -7,5 +8,11 @@ supervisor.user = "risu"
 
 [settings.proxy]
 enable = true
+
+[namespaces.biwa]
+dir = "/home/risu/.ghr/github.com/risu729/biwa"
+
+[slugs]
+biwa = { namespace = "biwa", daemon = "docs" }
 
 [daemons]


### PR DESCRIPTION
## Summary

- Register biwa namespace and slug so VitePress docs are reachable at `https://biwa.localhost`.
- Points at `docs` only (`ssh-server` is SSH, not an HTTP proxy target).
- Relax tombi strict schema for this file (`namespaces` / `slugs` are missing from the published schema).

## Config

```toml
[namespaces.biwa]
dir = "/home/risu/.ghr/github.com/risu729/biwa"

[slugs]
biwa = { namespace = "biwa", daemon = "docs" }
```

URL: `https://biwa.localhost` → `biwa/docs` (`localhost:5173`)
Worktrees: `<branch>.biwa.localhost`

## Test plan

- [ ] `pitchfork proxy status` shows `biwa` → `biwa/docs`
- [ ] `https://biwa.localhost` serves the docs after `docs` is ready
- [ ] Existing proxy (`:443`) / web UI (`:3120`) still work

## Summary by Sourcery

Configure the pitchfork proxy to serve the biwa VitePress docs under biwa.localhost and relax strict schema validation for the pitchfork config.

Enhancements:
- Register the biwa namespace and slug so the biwa docs daemon can be reached via the proxy.
- Disable strict tombi schema validation for the pitchfork config to accommodate missing namespace/slug fields in the published schema.