### PR TITLE
chore: install OpenSSH server

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -87,6 +87,8 @@ username=$(whoami)
 if ! groups "${username}" | grep --quiet --word-regexp docker; then
   sudo usermod --append --groups docker "${username}"
 fi
+
+sudo systemctl enable --now ssh.service
 '''
 
 [bootstrap.hooks.post-dotfiles]
@@ -134,6 +136,7 @@ fi
 "apt:graphviz" = "latest"
 "apt:libssl-dev" = "latest"
 "apt:llvm" = "latest"
+"apt:openssh-server" = "latest"
 "apt:parallel" = "latest"
 "apt:pkg-config" = "latest"
 "apt:strace" = "latest"


### PR DESCRIPTION
## Summary

- install `openssh-server` through the mise bootstrap package list
- enable and start `ssh.service` after package installation

## Why

Fresh WSL setups currently install the OpenSSH client configuration but do not install or activate the SSH server. Declaring the package and service lifecycle in the bootstrap configuration makes remote access available consistently after `mise bootstrap`.

## Impact

Running the WSL bootstrap installs OpenSSH Server and enables it to start with systemd. Existing installations converge safely because both the package declaration and `systemctl enable --now` are idempotent.

## Validation

- `mise config`
- `mise bootstrap packages apply --dry-run`
- `hk check --all`
- `git diff --check`

## Summary by Sourcery

Install and enable the OpenSSH server as part of the mise bootstrap for WSL environments.

New Features:
- Add OpenSSH server to the bootstrap package list so it is installed automatically.
- Enable and start the ssh.service during bootstrap to ensure the SSH server is running and persists across reboots.