### PR TITLE
chore(pitchfork): restore strict schema validation

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -110,6 +110,24 @@ done
 
 [bootstrap.hooks.final]
 run = '''
+pitchfork_ca="${HOME}/.local/state/pitchfork/proxy/ca.pem"
+if [ -f "${pitchfork_ca}" ] && command -v powershell.exe >/dev/null 2>&1; then
+  pitchfork_ca_windows=$(wslpath -w "${pitchfork_ca}")
+  powershell.exe -NoProfile -Command \
+    '& {
+      param([string]$CertPath)
+      $ErrorActionPreference = "Stop"
+      $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CertPath)
+      if (-not (Test-Path "Cert:\CurrentUser\Root\$($cert.Thumbprint)")) {
+        & certutil.exe -user -f -addstore Root $CertPath
+        if ($LASTEXITCODE -ne 0) {
+          throw "certutil failed with exit code $LASTEXITCODE"
+        }
+      }
+    }' \
+    "${pitchfork_ca_windows}"
+fi
+
 if [ -t 0 ] && [ -t 1 ]; then
   dotfiles_root=$(git rev-parse --show-toplevel)
   if ! mise exec -- bash -i -c "${dotfiles_root}/wsl/setup-git.ts"; then

--- a/mise.toml
+++ b/mise.toml
@@ -135,24 +135,6 @@ done
 
 [bootstrap.hooks.final]
 run = '''
-pitchfork_ca="${HOME}/.local/state/pitchfork/proxy/ca.pem"
-if [ -f "${pitchfork_ca}" ] && command -v powershell.exe >/dev/null 2>&1; then
-  pitchfork_ca_windows=$(wslpath -w "${pitchfork_ca}")
-  powershell.exe -NoProfile -Command \
-    '& {
-      param([string]$CertPath)
-      $ErrorActionPreference = "Stop"
-      $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CertPath)
-      if (-not (Test-Path "Cert:\CurrentUser\Root\$($cert.Thumbprint)")) {
-        & certutil.exe -user -f -addstore Root $CertPath
-        if ($LASTEXITCODE -ne 0) {
-          throw "certutil failed with exit code $LASTEXITCODE"
-        }
-      }
-    }' \
-    "${pitchfork_ca_windows}"
-fi
-
 if [ -t 0 ] && [ -t 1 ]; then
   dotfiles_root=$(git rev-parse --show-toplevel)
   if ! mise exec -- bash -i -c "${dotfiles_root}/wsl/setup-git.ts"; then

--- a/wsl/home/.config/pitchfork/config.toml
+++ b/wsl/home/.config/pitchfork/config.toml
@@ -7,6 +7,8 @@ supervisor.user = "risu"
 
 [settings.proxy]
 enable = true
+# Windows resolves *.localhost natively and does not use WSL's /etc/hosts.
+sync_hosts = false
 
 [namespaces.biwa]
 dir = "/home/risu/.ghr/github.com/risu729/biwa"

--- a/wsl/home/.config/pitchfork/config.toml
+++ b/wsl/home/.config/pitchfork/config.toml
@@ -1,5 +1,4 @@
 #:schema https://pitchfork.jdx.dev/schema.json
-#:tombi schema.strict = false
 
 [settings]
 general.mise = true

--- a/wsl/home/.config/pitchfork/config.toml
+++ b/wsl/home/.config/pitchfork/config.toml
@@ -7,8 +7,6 @@ supervisor.user = "risu"
 
 [settings.proxy]
 enable = true
-# Windows resolves *.localhost natively and does not use WSL's /etc/hosts.
-sync_hosts = false
 
 [namespaces.biwa]
 dir = "/home/risu/.ghr/github.com/risu729/biwa"


### PR DESCRIPTION
## Summary

- remove the temporary `#:tombi schema.strict = false` directive from the global Pitchfork configuration
- restore strict schema validation for the newly added namespace and slug registries

## Why

PR #3867 needed the override because Pitchfork’s published schema did not yet include `groups`, `namespaces`, or `slugs`. The schema fix from jdx/pitchfork#671 is now published at `https://pitchfork.jdx.dev/schema.json`, so Tombi can validate these fields normally.

## Impact

Schema mistakes in the Pitchfork configuration will once again be reported instead of being accepted under relaxed validation.

## Validation

- confirmed the live Pitchfork schema declares `groups`, `namespaces`, and `slugs`
- refreshed Tombi’s cached copy of the schema
- `hk check --all`
- `git diff --check`

## Summary by Sourcery

Enhancements:
- Remove the temporary override that disabled strict schema validation in the global Pitchfork configuration.