### PR TITLE
fix(pitchfork): trust proxy ca in windows

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -110,6 +110,24 @@ done
 
 [bootstrap.hooks.final]
 run = '''
+pitchfork_ca="${HOME}/.local/state/pitchfork/proxy/ca.pem"
+if [ -f "${pitchfork_ca}" ] && command -v powershell.exe >/dev/null 2>&1; then
+  pitchfork_ca_windows=$(wslpath -w "${pitchfork_ca}")
+  powershell.exe -NoProfile -Command \
+    '& {
+      param([string]$CertPath)
+      $ErrorActionPreference = "Stop"
+      $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CertPath)
+      if (-not (Test-Path "Cert:\CurrentUser\Root\$($cert.Thumbprint)")) {
+        & certutil.exe -user -f -addstore Root $CertPath
+        if ($LASTEXITCODE -ne 0) {
+          throw "certutil failed with exit code $LASTEXITCODE"
+        }
+      }
+    }' \
+    "${pitchfork_ca_windows}"
+fi
+
 if [ -t 0 ] && [ -t 1 ]; then
   dotfiles_root=$(git rev-parse --show-toplevel)
   if ! mise exec -- bash -i -c "${dotfiles_root}/wsl/setup-git.ts"; then

--- a/wsl/home/.config/pitchfork/config.toml
+++ b/wsl/home/.config/pitchfork/config.toml
@@ -7,6 +7,7 @@ supervisor.user = "risu"
 
 [settings.proxy]
 enable = true
+sync_hosts = false
 
 [namespaces.biwa]
 dir = "/home/risu/.ghr/github.com/risu729/biwa"

--- a/wsl/home/.config/pitchfork/config.toml
+++ b/wsl/home/.config/pitchfork/config.toml
@@ -7,6 +7,7 @@ supervisor.user = "risu"
 
 [settings.proxy]
 enable = true
+# Windows resolves *.localhost natively and does not use WSL's /etc/hosts.
 sync_hosts = false
 
 [namespaces.biwa]


### PR DESCRIPTION
## Summary

- disable Pitchfork hosts-file synchronization so Windows uses native `*.localhost` resolution
- import Pitchfork’s generated local CA into the Windows current-user trusted root store during bootstrap
- skip the import when the exact CA thumbprint is already trusted

## Validation

- `mise exec -- hk check`
- Windows trusted-root store contains the Pitchfork CA thumbprint
- Windows curl reaches `https://pitchfork.localhost/` with certificate validation enabled (`--ssl-no-revoke`) and returns HTTP 200
- rerunning the bootstrap import does not display another trust prompt

## Stack

Stacked on #3874, which restores strict validation for the same Pitchfork config.

## Summary by Sourcery

Trust Pitchfork’s local proxy CA on Windows clients and rely on native localhost resolution instead of hosts-file synchronization.

Bug Fixes:
- Ensure Windows trusts the Pitchfork-generated proxy CA so HTTPS requests to Pitchfork domains validate correctly.

Enhancements:
- Disable Pitchfork hosts-file synchronization to allow Windows to use its native *.localhost DNS resolution.
- Automatically import the Pitchfork-generated CA into the Windows current-user trusted root store during bootstrap, skipping re-imports when the CA is already trusted.