### PR TITLE
chore(herdr): disable onboarding

### DIFF
--- a/wsl/home/.config/herdr/config.toml
+++ b/wsl/home/.config/herdr/config.toml
@@ -1,3 +1,5 @@
+onboarding = false
+
 [ui]
 show_agent_labels_on_pane_borders = true
 agent_panel_sort = "priority"


### PR DESCRIPTION
## Summary

- persist Herdr's completed onboarding state in the WSL dotfiles
- prevent the onboarding flow from reappearing on fresh installations

## Validation

- `hk fix --no-progress wsl/home/.config/herdr/config.toml`
- `hk check --no-progress wsl/home/.config/herdr/config.toml`

## Summary by Sourcery

Chores:
- Persist Herdr's completed onboarding state in the WSL config to prevent onboarding from reappearing on new setups.