### PR TITLE
docs: avoid unnecessary force pushes

### DIFF
--- a/wsl/home/.codex/AGENTS.md
+++ b/wsl/home/.codex/AGENTS.md
@@ -16,6 +16,9 @@ instructions take precedence.
   existing PR if one exists; otherwise open a PR. Only leave changes local when
   explicitly requested.
 - Follow repository conventions for commits and PR titles.
+- Prefer normal commits and pushes when updating PRs. Do not rewrite history or
+  force-push merely to clean up a PR's commit log. Force-push only when
+  necessary, such as after a required rebase, and use `--force-with-lease`.
 - When the target repository is owned by the user, mark small, low-risk PRs
   ready for review by default. Use a draft for larger, unfinished, or uncertain
   changes.


### PR DESCRIPTION
## Summary

- prefer ordinary commits and pushes when updating pull requests
- prohibit force-pushing solely to tidy a PR's commit history
- allow force-pushing only when necessary, using `--force-with-lease`

## Validation

- `hk check --no-progress wsl/home/.codex/AGENTS.md`

## Summary by Sourcery

Documentation:
- Document preferred use of normal commits and pushes for PR updates and restrict force-pushes to necessary cases using --force-with-lease.