### PR TITLE
chore: add stable WSL Cloudflare IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ applications on Windows, such as browsers, IDEs, etc.
 
 Cloudflare Tunnel is installed in WSL and configured as a systemd user
 service. The service retries until a remotely-managed tunnel token is stored
-at `~/.config/cloudflared/tunnel-token`, then connects automatically.
+at `~/.config/cloudflared/tunnel-token`, then connects automatically. Bootstrap
+also assigns `10.1.0.20/32` to the WSL loopback interface for a stable
+Cloudflare private-network route to SSH.
 
 ## 🧭 Repository Structure
 

--- a/mise.toml
+++ b/mise.toml
@@ -99,9 +99,11 @@ sudo install --mode=0644 \
   "${dotfiles_root}/wsl/systemd/wsl-cloudflare-ip.service" \
   /etc/systemd/system/wsl-cloudflare-ip.service
 
-sudo systemctl daemon-reload
-sudo systemctl enable --now wsl-cloudflare-ip.service
-sudo systemctl enable --now ssh.service
+if [ -d /run/systemd/system ]; then
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now wsl-cloudflare-ip.service
+  sudo systemctl enable --now ssh.service
+fi
 '''
 
 [bootstrap.hooks.post-dotfiles]

--- a/mise.toml
+++ b/mise.toml
@@ -94,6 +94,24 @@ if ! groups "${username}" | grep --quiet --word-regexp docker; then
   sudo usermod --append --groups docker "${username}"
 fi
 
+sudo install --mode=0644 /dev/stdin \
+  /etc/systemd/system/wsl-cloudflare-ip.service <<'EOF'
+[Unit]
+Description=WSL Cloudflare private IP
+Before=ssh.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/ip address replace 10.1.0.20/32 dev lo
+ExecStop=-/usr/sbin/ip address del 10.1.0.20/32 dev lo
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now wsl-cloudflare-ip.service
 sudo systemctl enable --now ssh.service
 '''
 

--- a/mise.toml
+++ b/mise.toml
@@ -94,21 +94,10 @@ if ! groups "${username}" | grep --quiet --word-regexp docker; then
   sudo usermod --append --groups docker "${username}"
 fi
 
-sudo install --mode=0644 /dev/stdin \
-  /etc/systemd/system/wsl-cloudflare-ip.service <<'EOF'
-[Unit]
-Description=WSL Cloudflare private IP
-Before=ssh.service
-
-[Service]
-Type=oneshot
-ExecStart=/usr/sbin/ip address replace 10.1.0.20/32 dev lo
-ExecStop=-/usr/sbin/ip address del 10.1.0.20/32 dev lo
-RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target
-EOF
+dotfiles_root=$(git rev-parse --show-toplevel)
+sudo install --mode=0644 \
+  "${dotfiles_root}/wsl/systemd/wsl-cloudflare-ip.service" \
+  /etc/systemd/system/wsl-cloudflare-ip.service
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now wsl-cloudflare-ip.service

--- a/wsl/systemd/wsl-cloudflare-ip.service
+++ b/wsl/systemd/wsl-cloudflare-ip.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=WSL Cloudflare private IP
+Before=ssh.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/ip address replace 10.1.0.20/32 dev lo
+ExecStop=-/usr/sbin/ip address del 10.1.0.20/32 dev lo
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- track the root unit at `wsl/systemd/wsl-cloudflare-ip.service` and install it during `mise bootstrap`
- assign `10.1.0.20/32` to WSL's loopback interface before SSH starts
- document the stable Cloudflare private-network address

Cloudflare's `10.1.0.20/32` CIDR route remains an external configuration step.

## Validation

- `mise run check --lint`
- `systemd-analyze verify wsl/systemd/wsl-cloudflare-ip.service`
- verified the tracked unit matches `/etc/systemd/system/wsl-cloudflare-ip.service`
- verified `wsl-cloudflare-ip.service` and `ssh.service` are enabled and active
- verified `lo` has `10.1.0.20/32` and the local route resolves to `lo`
- verified sshd is listening on port 22