### PR TITLE
chore: enable systemd user lingering

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -100,6 +100,7 @@ sudo install --mode=0644 \
   /etc/systemd/system/wsl-cloudflare-ip.service
 
 if [ -d /run/systemd/system ]; then
+  sudo loginctl enable-linger "${username}"
   sudo systemctl daemon-reload
   sudo systemctl enable --now wsl-cloudflare-ip.service
   sudo systemctl enable --now ssh.service


### PR DESCRIPTION
## Summary

- enable systemd user lingering for the bootstrap user
- keep the user manager and services such as cloudflared running after login sessions end
- skip the operation when systemd is not PID 1, preserving container-based installer tests

This does not start WSL from Windows; it only keeps the user systemd manager available while the distribution is running.

## Validation

- `loginctl show-user risu -p Linger` → `Linger=yes`
- verified `dev.mise.cloudflared.service` remains enabled
- `mise run check --lint`

## Summary by Sourcery

Enhancements:
- Ensure the bootstrap user has systemd user lingering enabled to keep its user manager and services running after logout while preserving container-based installer behavior.