### PR TITLE
chore: persist WSL Cloudflare SSH CA

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -98,12 +98,21 @@ dotfiles_root=$(git rev-parse --show-toplevel)
 sudo install --mode=0644 \
   "${dotfiles_root}/wsl/systemd/wsl-cloudflare-ip.service" \
   /etc/systemd/system/wsl-cloudflare-ip.service
+sudo install --directory --mode=0755 /etc/ssh/sshd_config.d
+sudo install --mode=0644 \
+  "${dotfiles_root}/wsl/ssh/ca.pub" \
+  /etc/ssh/ca.pub
+sudo install --mode=0644 \
+  "${dotfiles_root}/wsl/ssh/10-cloudflare-access.conf" \
+  /etc/ssh/sshd_config.d/10-cloudflare-access.conf
 
 if [ -d /run/systemd/system ]; then
   sudo loginctl enable-linger "${username}"
   sudo systemctl daemon-reload
   sudo systemctl enable --now wsl-cloudflare-ip.service
+  sudo /usr/sbin/sshd -t
   sudo systemctl enable --now ssh.service
+  sudo systemctl reload ssh.service
 fi
 '''
 

--- a/wsl/ssh/10-cloudflare-access.conf
+++ b/wsl/ssh/10-cloudflare-access.conf
@@ -1,0 +1,3 @@
+PubkeyAuthentication yes
+PasswordAuthentication yes
+TrustedUserCAKeys /etc/ssh/ca.pub

--- a/wsl/ssh/ca.pub
+++ b/wsl/ssh/ca.pub
@@ -1,0 +1,2 @@
+# Cloudflare Access for Infrastructure SSH CA
+ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMKiw4/s/eZQuKJDb45HIOcCVrH/YR5AimX2sypSQ8Xo+ZVD38jC1Eemqcytu/PdPVcIuwD3KWDqn98M5I75tMU= open-ssh-ca@cloudflareaccess.org


### PR DESCRIPTION
## What changed

- store the existing Cloudflare Access for Infrastructure SSH CA public key in the WSL dotfiles
- install the CA and an `sshd_config.d` drop-in during bootstrap
- explicitly keep `PasswordAuthentication yes` while enabling CA-backed public-key authentication
- validate the effective sshd configuration before enabling and reloading the service

## Why

A recreated WSL instance should regain the same Cloudflare Access trust configuration without manually copying `/etc/ssh/ca.pub`. The CA is public material; the Cloudflare Tunnel token remains outside the repository.

## Validation

- `mise exec -- hk check mise.toml wsl/ssh/ca.pub wsl/ssh/10-cloudflare-access.conf`
- `sudo /usr/sbin/sshd -t`
- verified effective settings: `PubkeyAuthentication yes`, `PasswordAuthentication yes`, and `TrustedUserCAKeys /etc/ssh/ca.pub`
- reloaded `ssh.service` and confirmed it remains active

## Summary by Sourcery

Persist and apply Cloudflare Access SSH CA configuration for WSL instances during bootstrap, ensuring SSH trusts the stored CA while keeping password authentication enabled.

Enhancements:
- Install the stored Cloudflare SSH CA public key and a dedicated sshd drop-in config during WSL bootstrap.
- Ensure sshd_config.d directory and CA key are provisioned to /etc/ssh for consistent trust across recreated WSL instances.
- Validate the effective sshd configuration before enabling and reloading the SSH service to avoid misconfiguration.