### PR TITLE
chore: install GitHub stacked PR tools

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -123,9 +123,13 @@ sudo update-desktop-database
 
 [bootstrap.hooks.post-tools]
 run = '''
+mise exec -- gh extension install github/gh-stack --force
+
 for agent in universal claude-code; do
   mise exec -- gh skill install mattpocock/skills skills/productivity/grilling \
     --agent "${agent}" --scope user --pin main --force
+  mise exec -- gh skill install github/gh-stack gh-stack \
+    --agent "${agent}" --scope user --force
 done
 
 for integration in claude codex; do


### PR DESCRIPTION
## Summary

- install or upgrade the official `github/gh-stack` extension during the post-tools bootstrap hook
- install the `gh-stack` agent skill at user scope for universal agents and Claude Code

## Why

Make GitHub stacked pull request tooling available automatically on newly bootstrapped machines and keep existing installations current.

## Validation

- `tombi lint mise.toml`
- `mise run check`
- exercised both hook commands locally
- verified `gh stack version 0.1.0`
- verified skill installation under `~/.agents/skills` and `~/.claude/skills`

## Summary by Sourcery

Configure bootstrap tooling to ensure GitHub stacked PR support is installed and kept up to date on developer machines.

Build:
- Add post-tools bootstrap command to install or upgrade the github/gh-stack GitHub CLI extension.
- Install the gh-stack agent skill at user scope for universal and Claude Code agents during tooling bootstrap.